### PR TITLE
Example review

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -436,9 +436,9 @@
         "@context": "http://purl.org/hydra/core/context.jsonld",
         "@id": "http://api.example.com/doc/",
         ****"@type": "ApiDocumentation"****,
-        ****"title"****: ####"The name of the API",####
-        ****"description"****: ####"A short description of the API",####
-        ****"entrypoint"****: ####"URL of the API's main entry point",####
+        ****"title"****: ####"The name of the API"####,
+        ****"description"****: ####"A short description of the API"####,
+        ****"entrypoint"****: ####"URL of the API's main entry point"####,
         ****"supportedClasses"****: [
           ####... The classes known to be supported by the Web API ...####
         ],
@@ -520,8 +520,8 @@
         "@context": "http://purl.org/hydra/core/context.jsonld",
         "@id": "http://api.example.com/doc/#Comment",
         "@type": "Class",
-        "title": ####"The name of the class",####
-        "description": ####"A short description of the class.",####
+        "title": ####"The name of the class"####,
+        "description": ####"A short description of the class."####,
         "supportedProperties": [
           ####... The properties known to be supported by the class ...####
         ],


### PR DESCRIPTION
Unifies where to place the leading comma in JSON-LD code when the value is emphasized.
