### PR TITLE
changed schema.org spec to use respec-w3c-common from w3.org

### DIFF
--- a/spec/latest/schema.org/index.html
+++ b/spec/latest/schema.org/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>Integration of Hydra into Schema.org</title>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<script type="text/javascript" src="../../js/respec-w3c-common.js" class="remove"></script>
+<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">


### PR DESCRIPTION
http://www.hydra-cg.com/spec/latest/schema.org/

> Failed to load resource: the server responded with a status of 404 (Not Found) http://www.hydra-cg.com/spec/js/respec-w3c-common.js
