### PR TITLE
Change readonly/writeonly to readable/writeable.

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -19,8 +19,8 @@
     "SupportedProperty": "hydra:SupportedProperty",
     "property": { "@id": "hydra:property", "@type": "@vocab" },
     "required": "hydra:required",
-    "readonly": "hydra:readonly",
-    "writeonly": "hydra:writeonly",
+    "readable": "hydra:readable",
+    "writeable": "hydra:writeable",
     "supportedOperation": { "@id": "hydra:supportedOperation", "@type": "@id" },
     "Operation": "hydra:Operation",
     "CreateResourceOperation": "hydra:CreateResourceOperation",
@@ -180,19 +180,19 @@
       "vs:term_status": "testing"
     },
     {
-      "@id": "hydra:readonly",
+      "@id": "hydra:readable",
       "@type": "rdf:Property",
-      "label": "ready-only",
-      "comment": "True if the property is read-only, false otherwise.",
+      "label": "readable",
+      "comment": "True if the client can retrieve the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
       "vs:term_status": "testing"
     },
     {
-      "@id": "hydra:writeonly",
+      "@id": "hydra:writeable",
       "@type": "rdf:Property",
-      "label": "write-only",
-      "comment": "True if the property is write-only, false otherwise.",
+      "label": "writeable",
+      "comment": "True if the client can change the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
       "vs:term_status": "testing"

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -490,8 +490,8 @@
             ****"@type": "SupportedProperty"****,
             ****"property"****: "#property", ####// The property####
             ****"required"****: true, ####// Is the property required in a request to be valid?####
-            ****"readonly"****: false, ####// Can the property's value be modified or is it read-only?####
-            ****"writeonly"****: true ####// Can the property's value be retrieved or is it write-only?####
+            ****"readable"****: false, ####// Can the client retrieve the property's value?####
+            ****"writeable"****: true ####// Can the client change the property's value?####
           }
         ]
       }


### PR DESCRIPTION
Implements the proposed resolution for #14.

Note that I have explicitly mentioned “readable/writeable **for a client**”, as we discussed that these properties may depend on the client accessing the response (like hypermedia controls do).