### PR TITLE
Explicitly mention namespace in Core Vocabulary document

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -169,6 +169,10 @@
     explicitly marked as non-normative. Everything else in this
     specification is normative.</p>
 
+  <p>The namespace of the Hydra Core Vocabulary is
+    <code>http://www.w3.org/ns/hydra/core#</code>,
+    and the suggested prefix is <code>hydra</code>.</p>
+
   <p class="issue">Conformance for Hydra clients should probably not be
     specified in this document.</p>
 


### PR DESCRIPTION
The current Core Vocabulary document did not explicitly mention the namespace and suggested prefix.
