### PR TITLE
improved examples using Comment class

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -476,11 +476,11 @@
       associated with.</p>
 
     <pre class="example" data-transform="updateExample"
-         title="Defining a class and documenting its supported properties">
+         title="Defining/augmenting a class and documenting its supported properties">
       <!--
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-        "@id": "http://api.example.com/doc/#Comment",
+        "@id": "http://schema.org/Comment",
         ****"@type": "Class"****,
         ****"title"****: ####"The name of the class"####,
         ****"description"****: ####"A short description of the class."####,
@@ -488,10 +488,17 @@
           ####... Properties known to be supported by the class ...####
           {
             ****"@type": "SupportedProperty"****,
-            ****"property"****: "#property", ####// The property####
+            ****"property"****: "http://schema.org/text", ####// URI of the property####
             ****"required"****: true, ####// Is the property required in a request to be valid?####
-            ****"readable"****: false, ####// Can the client retrieve the property's value?####
+            ****"readable"****: true, ####// Can the client retrieve the property's value?####
             ****"writeable"****: true ####// Can the client change the property's value?####
+          },
+          {
+            "@type": "SupportedProperty",
+            "property": "http://schema.org/dateCreated",
+            "required": false,
+            "readable": true,
+            "writeable": false
           }
         ]
       }
@@ -504,11 +511,11 @@
       a class.</p>
 
     <pre class="example" data-transform="updateExample"
-         title="Defining a class and documenting its supported operations">
+         title="Defining/augmenting a class and documenting its supported operations">
       <!--
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-        "@id": "http://api.example.com/doc/#Comment",
+        "@id": "http://schema.org/Comment",
         "@type": "Class",
         "title": ####"The name of the class"####,
         "description": ####"A short description of the class."####,
@@ -543,8 +550,8 @@
             "@type": "CreateResourceOperation",
             "title": "Creates a new comment",
             "method": "POST",
-            "expects": "http://api.example.com/doc/#Comment",
-            "returns": "http://api.example.com/doc/#Comment",
+            "expects": "http://schema.org/Comment",
+            "returns": "http://schema.org/Comment",
             "possibleStatus": [****
               ####... Statuses that should be expected and handled properly ...####
             ****]


### PR DESCRIPTION
During presentation at http://paris.apidays.io/ last Tuesday I showed examples of defining properties of Comment class and operation on collection of comments.
http://www.slideshare.net/elfpavlik/api-standardization-work-in-w3c-groups/94

IMO with modifications proposed in his PR one could explain it much more easily. Now it also encourages to reuse existing vocabularies like schema.org. Which matches @lanthaler's presentation from last year http://www.slideshare.net/lanthaler/the-web-is-changing-from-strings-to-things/8