### PR TITLE
Proof of concept for authoring spec in markdown

### DIFF
--- a/spec/js/respec-w3c-extensions.js
+++ b/spec/js/respec-w3c-extensions.js
@@ -114,7 +114,7 @@ var preProc =
                 classOverview += '<ul>';
                 $('#vocabulary-overview').append(classOverview);
             });
-        }).error(function(jqxhr) {
+        }).catch(function(jqxhr) {
             alert("Can't load the vocabulary.");
         });
     }

--- a/spec/js/respec-w3c-extensions.js
+++ b/spec/js/respec-w3c-extensions.js
@@ -11,7 +11,9 @@ var preProc =
             return;
         }
 
-        window.fetch('core.jsonld').then(function(vocab) {
+        window.fetch('core.jsonld')
+        .then(function(res) { return res.text(); })
+        .then(function(vocab) {
             var options = { "base": "http://www.w3.org/ns/hydra/" };
             var context = {
                 "hydra": "http://www.w3.org/ns/hydra/core#",

--- a/spec/js/respec-w3c-extensions.js
+++ b/spec/js/respec-w3c-extensions.js
@@ -11,7 +11,7 @@ var preProc =
             return;
         }
 
-        $.getJSON('core.jsonld', function(vocab) {
+        window.fetch('core.jsonld').then(function(vocab) {
             var options = { "base": "http://www.w3.org/ns/hydra/" };
             var context = {
                 "hydra": "http://www.w3.org/ns/hydra/core#",

--- a/spec/js/respec-w3c-extensions.js
+++ b/spec/js/respec-w3c-extensions.js
@@ -5,8 +5,8 @@ var localBibliography = {
     "HYDRA-TPF": "Ruben Verborgh. <cite><a href=\"http://www.hydra-cg.com/spec/latest/triple-pattern-fragments/\">Triple Pattern Fragments</a>.</cite> Unofficial Draft. URL: <a href=\"http://www.hydra-cg.com/spec/latest/triple-pattern-fragments/\">http://www.hydra-cg.com/spec/latest/triple-pattern-fragments/</a>."
 };
 
-var preProc = {
-    apply:  function(c) {
+var preProc = 
+    function(c) {
         if (0 === $('#vocabulary-classes').length) {
             return;
         }
@@ -116,7 +116,7 @@ var preProc = {
             alert("Can't load the vocabulary.");
         });
     }
-};
+;
 
 function _esc(s) {
     s = s.replace(/&/g,'&amp;');

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -74,7 +74,9 @@
           // { uri: "diff-20120712.html", label: "diff to previous version" }
           { uri: "core.jsonld", label: "JSON-LD" },
           { uri: "core.ttl", label: "Turtle" },
-      ]
+      ],
+    
+      format: "markdown"
   };
 //]]>
 </script>
@@ -950,12 +952,12 @@
 </section>
 
 <section class="informative">
-  <h2>Acknowledgements</h2>
+  ## Acknowledgements
 
-  <p>The authors would like to thank the following individuals for contributing
-    their ideas and providing feedback for writing this specification:
-    Arnau Siches, Mark Baker, Martijn Faassen, Matthias Lehmann, Ruben Verborgh,
-    Ryan J. McDonough, Sam Goto, Thomas Hoppe, @wasabiwimp (on GitHub).</p>
+  The authors would like to thank the following individuals for contributing
+  their ideas and providing feedback for writing this specification:
+  Arnau Siches, Mark Baker, Martijn Faassen, Matthias Lehmann, Ruben Verborgh,
+  Ryan J. McDonough, Sam Goto, Thomas Hoppe, @wasabiwimp (on GitHub).
 </section>
 
 <section class="appendix informative">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -166,26 +166,7 @@
     granularity.</p>
 </section>
 
-<section>
-  <h2>Conformance</h2>
-
-  <p>This specification describes the conformance criteria for
-    <dfn data-lt="Hydra API documentation">Hydra API documentations</dfn>
-    and <dfn data-lt="Hydra client">Hydra clients</dfn>. These criteria are
-    relevant to authors, authoring tool implementers, and client
-    implementers. All authoring guidelines, diagrams, examples, and notes
-    in this specification are non-normative, as are all sections
-    explicitly marked as non-normative. Everything else in this
-    specification is normative.</p>
-
-  <p class="issue">Conformance for Hydra clients should probably not be
-    specified in this document.</p>
-
-  <p class="issue">Add normative statements</p>
-
-  <p>The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
-    SHOULD NOT, RECOMMENDED, NOT RECOMMENDED, MAY, and OPTIONAL in this
-    specification have the meaning defined in [[!RFC2119]].</p>
+<section data-include="section/conformance.html">
 </section>
 
 <section class="informative">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -3,9 +3,9 @@
 <head>
 <title>Hydra Core Vocabulary</title>
 <meta charset="utf-8">
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch|gated"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch|gated"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">
 //<![CDATA[

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>Hydra Core Vocabulary</title>
 <meta charset="utf-8">
-<script type="text/javascript" src="https://raw.githubusercontent.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
+<script type="text/javascript" src="https://cdn.rawgit.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8">
 <script type="text/javascript" src="https://cdn.rawgit.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch|gated"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">
 //<![CDATA[

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -166,7 +166,7 @@
     granularity.</p>
 </section>
 
-<section id="conformance" data-include="section/conformance.html" data-include-format="markdown">
+<section id="conformance" data-include="section/conformance.html">
 </section>
 
 <section class="informative">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -166,7 +166,7 @@
     granularity.</p>
 </section>
 
-<section data-include="section/conformance.html">
+<section data-include="section/conformance.html" data-include-forma="markdown">
 </section>
 
 <section class="informative">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -166,7 +166,7 @@
     granularity.</p>
 </section>
 
-<section data-include="section/conformance.html" data-include-forma="markdown">
+<section id="conformance" data-include="section/conformance.html" data-include-format="markdown">
 </section>
 
 <section class="informative">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>Hydra Core Vocabulary</title>
 <meta charset="utf-8">
-<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
+<script type="text/javascript" src="https://raw.githubusercontent.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -4,7 +4,7 @@
 <title>Hydra Core Vocabulary</title>
 <meta charset="utf-8">
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch|gated"></script>
-<script type="text/javascript" src="https://cdn.rawgit.com/w3c/respec/develop/builds/respec-w3c-common.js" async class="remove"></script>
+<script type="text/javascript" src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
 <script type="text/javascript" src="../../js/jsonld.js" class="remove"></script>
 <script type="text/javascript" src="../../js/respec-w3c-extensions.js" class="remove"></script>
 <script type="text/javascript" class="remove">

--- a/spec/latest/core/section/conformance.html
+++ b/spec/latest/core/section/conformance.html
@@ -1,5 +1,3 @@
-## Conformance
-
 This specification describes the conformance criteria for
 <dfn data-lt="Hydra API documentation">Hydra API documentations</dfn>
 and <dfn data-lt="Hydra client">Hydra clients</dfn>. These criteria are

--- a/spec/latest/core/section/conformance.html
+++ b/spec/latest/core/section/conformance.html
@@ -1,0 +1,20 @@
+## Conformance
+
+This specification describes the conformance criteria for
+<dfn data-lt="Hydra API documentation">Hydra API documentations</dfn>
+and <dfn data-lt="Hydra client">Hydra clients</dfn>. These criteria are
+relevant to authors, authoring tool implementers, and client
+implementers. All authoring guidelines, diagrams, examples, and notes
+in this specification are non-normative, as are all sections
+explicitly marked as non-normative. Everything else in this
+specification is normative.</p>
+
+<p class="issue">
+Conformance for Hydra clients should probably not be specified in this document.
+</p>
+
+<p class="issue">Add normative statements</p>
+
+The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD,
+SHOULD NOT, RECOMMENDED, NOT RECOMMENDED, MAY, and OPTIONAL in this
+specification have the meaning defined in [[!RFC2119]].


### PR DESCRIPTION
In the previously used version of ReSpec only inline markdown was supported. With great help from @marcoscaceres, now it's possible to create specification sections in imported markdown files (see w3c/respec#993)

Please let me know if you'd like to explore splitting the spec in smaller chunks.

Also, I refactored the `respec-w3c-extensions.js` file to be independent of jQuery (see [this comment](https://github.com/w3c/respec/issues/993#issuecomment-269773682))