### PR TITLE
"@type": "@id" in JSON-LD context of use cases

### DIFF
--- a/drafts/use-cases/0.intro.md
+++ b/drafts/use-cases/0.intro.md
@@ -46,7 +46,7 @@ These would be:
             "@id": "hydra:title",
             "@type": "xsd:string"
         },
-        "operations": {
+        "operation": {
             "@id": "hydra:operation",
             "@type": "@id"
         },

--- a/drafts/use-cases/0.intro.md
+++ b/drafts/use-cases/0.intro.md
@@ -56,25 +56,25 @@ These would be:
         },
         "returns": {
             "@id": "hydra:returns",
-            "@type": "@id"
+            "@type": "@vocab"
         },
         "expects": {
             "@id": "hydra:expects",
-            "@type": "@id"
+            "@type": "@vocab"
         },
-        "supportedClasses": {
+        "supportedClass": {
             "@id": "hydra:supportedClass",
-            "@type": "@id"
+            "@type": "@vocab"
         },
-        "supportedProperties": {
+        "supportedProperty": {
             "@id": "hydra:supportedProperty",
-            "@type": "@id"
+            "@type": "@vocab"
         },
         "property": {
             "@id": "hydra:property",
-            "@type": "@id"
+            "@type": "@vocab"
         },
-        "members": {
+        "member": {
             "@id": "hydra:member",
             "@type": "@id"
         },

--- a/drafts/use-cases/0.intro.md
+++ b/drafts/use-cases/0.intro.md
@@ -33,7 +33,7 @@ These would be:
 - to simplify, the host was dropped from all Urls. We can assume an example like http://example.com/.
 
 ### JSON-LD context
-```javascript
+```json
 {
     "@context": {
         "hydra": "http://www.w3.org/ns/hydra/core#",
@@ -48,7 +48,7 @@ These would be:
         },
         "operations": {
             "@id": "hydra:operation",
-            "@type": "hydra:Operation"
+            "@type": "@id"
         },
         "method": {
             "@id": "hydra:method",
@@ -56,15 +56,15 @@ These would be:
         },
         "returns": {
             "@id": "hydra:returns",
-            "@type": "hydra:Class"
+            "@type": "@id"
         },
         "expects": {
             "@id": "hydra:expects",
-            "@type": "hydra:Class"
+            "@type": "@id"
         },
         "supportedClasses": {
             "@id": "hydra:supportedClass",
-            "@type": "hydra:Class"
+            "@type": "@id"
         },
         "supportedProperties": {
             "@id": "hydra:supportedProperty",
@@ -72,7 +72,7 @@ These would be:
         },
         "property": {
             "@id": "hydra:property",
-            "@type": "rdf:Property"
+            "@type": "@id"
         },
         "members": {
             "@id": "hydra:member",
@@ -85,7 +85,7 @@ These would be:
         "Event": {
             "@id": "schema:Event",
             "@type": "@id"
-        }
+        },
         "eventName": {
             "@id": "schema:name",
             "@type": "xsd:string"


### PR DESCRIPTION
as reported in https://github.com/HydraCG/Specifications/pull/113#pullrequestreview-35602303

https://www.w3.org/TR/json-ld/#h_note_1
>  It is worth noting that the `@type` keyword is not only used to specify the type of a node but also to express typed values (as described in section 6.4 Typed Values) and to type coerce values (as described in section 6.5 Type Coercion). **Specifically, `@type` cannot be used in a context to define a node's type**. For a detailed description of the differences, please refer to section 6.4 Typed Values.