### PR TITLE
Same IRI must not denote both - the operation and the api resource which supports that operation

### DIFF
--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -13,7 +13,7 @@ There are several possibilities here. One of them would be to use a *@graph* not
     "@graph": [
         {
             "@id": "/api",
-            "operations": [
+            "operation": [
                 {
                     "@type": "hydra:Operation",
                     "title": "List events",

--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -1,29 +1,31 @@
 ### Security considerations
 
 #### JSON array root security issues
-Due to security issues with JSON arrays which can be exploited in some circumstances, 
+Due to security issues with JSON arrays which can be exploited in some circumstances,
 there may be a need to avoid pure arrays in favour of a JSON object.
 In the scenario above, server returned a single object, which won't cause issues.
-But it is possible to return multiple resources, resulting in an JSON array returned 
+But it is possible to return multiple resources, resulting in an JSON array returned
 (server may not use any JSON-LD context or it may be completely different from the one used by the client).
 There are several possibilities here. One of them would be to use a *@graph* notation, i.e.:
 
-```javascript
+```json
 {
     "@graph": [
         {
             "@id": "/api",
             "operations": [
                 {
-                    "@id": "/api/events",
-                    "title": "Events",
-                    "httpMethod": "GET",
+                    "@id": "/api#list-events",
+                    "@type": "hydra:Operation",
+                    "title": "List events",
+                    "method": "GET",
                     "returns": "hydra:Collection"
                 },
                 {
-                    "@id": "/api/events",
+                    "@id": "/api#add-event",
+                    "@type": "hydra:Operation",
                     "title": "Create new event",
-                    "httpMethod": "POST",
+                    "method": "POST",
                     "expects": "schema:Event"
                 }
             ]

--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -15,14 +15,12 @@ There are several possibilities here. One of them would be to use a *@graph* not
             "@id": "/api",
             "operations": [
                 {
-                    "@id": "/api#list-events",
                     "@type": "hydra:Operation",
                     "title": "List events",
                     "method": "GET",
                     "returns": "hydra:Collection"
                 },
                 {
-                    "@id": "/api#add-event",
                     "@type": "hydra:Operation",
                     "title": "Create new event",
                     "method": "POST",

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -1,3 +1,4 @@
+
 ## Entry point
 
 ### Story
@@ -29,22 +30,22 @@ HTTP 200 OK
 {
     "@id": "/api",
     "@type": "hydra:EntryPoint",
-    "operation": [
-        {
-            "@type": "hydra:Operation",
-            "title": "List events",
-            "method": "GET",
-            "returns": "hydra:Collection"
-        },
-        {
+    "events": {
+        "@id": "/api/events", 
+        "title": "List of events",
+        "@type": "hydra:Collection"
+        "operation": {
             "@type": "hydra:Operation",
             "title": "Create new event",
             "method": "POST",
             "expects": "schema:Event"
         }
-    ]
+    }
 }
 ```
+
+**Note:** The `events` property would need to be specified by the API. Hydra currently doesn't define any
+concepts which would allow to reference collections and describe their items in more details.
 
 With this details, client application is aware of two possible operations that can be made from that point:
 

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -31,14 +31,12 @@ HTTP 200 OK
     "@type": "hydra:EntryPoint",
     "operations": [
         {
-            "@id": "/api#list-events",
             "@type": "hydra:Operation",
             "title": "List events",
             "method": "GET",
             "returns": "hydra:Collection"
         },
         {
-            "@id": "/api#add-event",
             "@type": "hydra:Operation",
             "title": "Create new event",
             "method": "POST",
@@ -65,8 +63,8 @@ But in RDFS environment, it is possible to use only *hydra:method* and *hydra:ex
 which is fully legal as the entailment process would extend the resource */events* with additional
 statement (in Turtle):
 
-```
-</api#list-events> a hydra:Operation .
+```ttl
+[] a hydra:Operation .
 ```
 
 This is due to fact that Hydra Core Vocabulary provides an *rdfs:domain* for *hydra:method* .

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -20,24 +20,25 @@ in a configuration or in the input field.
 Once provided, the application is expected to connect to the entry-point of the Web API and download initial
 details on what else can be done with that API from that very point.
 
-```
+```http
 GET /api
 
 HTTP 200 OK
 ```
-```javascript
+```json
 {
     "@id": "/api",
+    "@type": "hydra:EntryPoint",
     "operations": [
         {
-            "@id": "/api/events",
+            "@id": "/api#list-events",
             "@type": "hydra:Operation",
-            "title": "Events",
+            "title": "List events",
             "method": "GET",
             "returns": "hydra:Collection"
         },
         {
-            "@id": "/api/events#new",
+            "@id": "/api#add-event",
             "@type": "hydra:Operation",
             "title": "Create new event",
             "method": "POST",
@@ -60,12 +61,12 @@ GET operations returning *hydra:Collection* and displays them in a main menu.
 #### RDFS entailment and OWL Reasoning capabilities
 Another thing is how far the client should be pushed into the reasoning process.
 In the example above, both operations have their type explicitely expressed with *"@type"* keyword.
-But in RDFS environment, it is possible to use only *hydra:method* and *hydra:expects* predicates, 
+But in RDFS environment, it is possible to use only *hydra:method* and *hydra:expects* predicates,
 which is fully legal as the entailment process would extend the resource */events* with additional
 statement (in Turtle):
 
 ```
-</api/events> a hydra:Operation .
+</api#list-events> a hydra:Operation .
 ```
 
 This is due to fact that Hydra Core Vocabulary provides an *rdfs:domain* for *hydra:method* .

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -29,7 +29,7 @@ HTTP 200 OK
 {
     "@id": "/api",
     "@type": "hydra:EntryPoint",
-    "operations": [
+    "operation": [
         {
             "@type": "hydra:Operation",
             "title": "List events",

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -33,7 +33,7 @@ HTTP 200 OK
     "events": {
         "@id": "/api/events", 
         "title": "List of events",
-        "@type": "hydra:Collection"
+        "@type": "hydra:Collection",
         "operation": {
             "@type": "hydra:Operation",
             "title": "Create new event",

--- a/drafts/use-cases/2.api-documentation.md
+++ b/drafts/use-cases/2.api-documentation.md
@@ -18,7 +18,7 @@ for (var $class of apiDocumentation.supportedClasses) {
 The documentation obtain may be a large payload,
 thus client is expected to store it temporarily at least for the current session.
 
-```
+```http
 GET /
 
 HTTP 200 OK
@@ -28,13 +28,13 @@ GET /api?documentation
 
 HTTP 200 OK
 ```
-```javascript
+```json
 {
     "@id": "/api?documentation",
-    "supportedClasses": [
+    "supportedClass": [
         {
             "@id": "schema:Event",
-            "suportedProperties": [
+            "supportedProperty": [
                 {
                     "property": {
                         "@id": "eventName"
@@ -97,7 +97,7 @@ For simple scenarios it may be just _xsd:string_, but what if server will come o
 #### Embedding class supported operations
 We could embed within each of the supported class details on what can be done with those classes,
 i.e. how can we obtain all instances or how we can create a new one.
-This may be an alternative to entry point, where an UI application could create it's main menu 
+This may be an alternative to entry point, where an UI application could create it's main menu
 presented to the user with all possibilities, from which some may be denied later.
 In case of an entry-point and embedded hypermedia controls,
 only those that are allowed in the current state are expect .

--- a/drafts/use-cases/3.1.extensions-considerations.md
+++ b/drafts/use-cases/3.1.extensions-considerations.md
@@ -4,11 +4,11 @@
 Without judging whether it is a real issue or not, the application is not fully aware of what will come.
 It knows only that a collection of items will be returned, but the type of these items is not disclosed.
 Also there is no hint before fetching whether the collection is complete or partial.
-Hydra Core Vocabulary allows partial collections, 
+Hydra Core Vocabulary allows partial collections,
 but it's unclear how to denote that fact before fetching the collection.
 This may lead to situation when an application can be "surprised"
-either by receiving a partial collection forcing it to make additional calls to fill the view 
-(in our case a monthly view of the calendar), or by a complete collection which may contain dozens of items 
+either by receiving a partial collection forcing it to make additional calls to fill the view
+(in our case a monthly view of the calendar), or by a complete collection which may contain dozens of items
 (which are not needed at the time being).
 
 #### Hypermedia controls and data separation
@@ -21,7 +21,7 @@ the latter may prove tricky for pure ReST approach forcing the client to be more
 
 Again, named graphs would come in handy in this situation, i.e.:
 
-```javascript
+```json
 {
     "@graph": [
         {
@@ -29,16 +29,20 @@ Again, named graphs would come in handy in this situation, i.e.:
             "@graph": [
                 {
                     "@id": "/api/events",
-                    "hydra:operation: [
+                    "operations": [
                         {
-                            "@id": "/api/events",
-                            "hydra:method": "GET",
-                            "hydra:returns": "hydra:Collection"
+                            "@id": "/api#list-events",
+                            "@type": "hydra:Operation",
+                            "title": "List events",
+                            "method": "GET",
+                            "returns": "hydra:Collection"
                         },
                         {
-                            "@id": "/api/events",
-                            "hydra:method": "POST",
-                            "hydra:expects": "schema:Event"
+                            "@id": "/api#add-event",
+                            "@type": "hydra:Operation",
+                            "title": "Create new event",
+                            "method": "POST",
+                            "expects": "schema:Event"
                         }
                     ],
                     "members": [
@@ -47,7 +51,7 @@ Again, named graphs would come in handy in this situation, i.e.:
                         }
                     ]
                 }
-            }
+            ]
         },
         {
             "@graph": [

--- a/drafts/use-cases/3.1.extensions-considerations.md
+++ b/drafts/use-cases/3.1.extensions-considerations.md
@@ -31,14 +31,12 @@ Again, named graphs would come in handy in this situation, i.e.:
                     "@id": "/api/events",
                     "operations": [
                         {
-                            "@id": "/api#list-events",
                             "@type": "hydra:Operation",
                             "title": "List events",
                             "method": "GET",
                             "returns": "hydra:Collection"
                         },
                         {
-                            "@id": "/api#add-event",
                             "@type": "hydra:Operation",
                             "title": "Create new event",
                             "method": "POST",

--- a/drafts/use-cases/3.1.extensions-considerations.md
+++ b/drafts/use-cases/3.1.extensions-considerations.md
@@ -29,7 +29,7 @@ Again, named graphs would come in handy in this situation, i.e.:
             "@graph": [
                 {
                     "@id": "/api/events",
-                    "operations": [
+                    "operation": [
                         {
                             "@type": "hydra:Operation",
                             "title": "List events",
@@ -43,7 +43,7 @@ Again, named graphs would come in handy in this situation, i.e.:
                             "expects": "schema:Event"
                         }
                     ],
-                    "members": [
+                    "member": [
                         {
                             "@id": "/api/events/1"
                         }

--- a/drafts/use-cases/3.obtaining-events.md
+++ b/drafts/use-cases/3.obtaining-events.md
@@ -1,14 +1,14 @@
 ## Obtaining events
 
-### Story 
+### Story
 As an API consumer
 I want to be able to retrieve all members of a collection
 So that I can process them further.
- 
+
 ### Example
-As an application user 
-I want to display all my events 
-So I can find out what awaits me in the nearest future. 
+As an application user
+I want to display all my events
+So I can find out what awaits me in the nearest future.
 
 ### Usage
 ```javascript
@@ -23,16 +23,16 @@ for (var member of data.members) {
 Once the application obtained a discovered either from the entry-point or the API documentation URL to the
 events, it sends a GET request to that URL and fetches the events:
 
-```
+```http
 GET /api/events
 
 HTTP 200 OK
 ```
-```javascript
+```json
 {
     "@id": "/api/events",
     "totalItems": 1,
-    "members": [
+    "member": [
         {
             "@id": "/api/events/1",
             "eventName": "Event 1",


### PR DESCRIPTION
I changed IRIs that denote operations to:
* `/api#list-events`
* `/api#add-event`

Possibly I should have used instead:
* `/api?documentation#list-events`
* `/api?documentation#add-event`

Any resource which supports any of those operations can possibly just reference their IRIs eg.

```json
{
  "@id": "/api/events",
  "operations": [
    "/api#list-events",
    "/api#add-event"
  ]
}
```

BTW in 1.entry-point.md the entry point `/api` advertises support for those two operations, possibly a bug?

and don't use https://www.w3.org/TR/json-ld/#embedding
