### PR TITLE
Add use case: Update resource

### DIFF
--- a/drafts/use-cases/6.updating-event.md
+++ b/drafts/use-cases/6.updating-event.md
@@ -14,7 +14,9 @@ So I can amend content.
 var client = new HydraClient();
 var event = client.get("/api/events/1")
 event.eventName = "Some new event name.";
-client.invoke(event.getOperations().filter(op => op.method == "PUT")[0], event);
+client.invoke(
+    event.getOperations()
+        .filter(op => op[@type].find(type => type === schema.ReplaceAction)[0], event);
 ```
 
 ### Details

--- a/drafts/use-cases/6.updating-event.md
+++ b/drafts/use-cases/6.updating-event.md
@@ -22,7 +22,7 @@ Application needs to be able to modify existing resources. This use case relies 
 the resource is first obtained from the server, amended and sent back, but this is not always true.
 Additionaly, the operation used for the update is taken from the hypermedia controls embedded in the 
 resource and the target method is dicovered with an anti-patter binding it to HTTP protocol.
-Regardles all of these, the communication would look like the example below::
+Regardles all of these, the communication would look like the example below:
 
 ```
 GET /api/events/1
@@ -75,6 +75,6 @@ of what kind of data will be provided by the server, thus a simple question may 
 *What gets updated?*
 
 The simplest answer would be that whole resource is replaced with new incoming data.
-But it is easy to imagine a situation, where a client may implicitely state what kind of data to 
+But it is easy to imagine a situation, where a client may explicitely state what kind of data to 
 include when obtaining a resource, thus server won't know which data to update and which to leave 
 untouched. These considerations could multiplied, thus some explicit directions may be needed.

--- a/drafts/use-cases/6.updating-event.md
+++ b/drafts/use-cases/6.updating-event.md
@@ -1,0 +1,80 @@
+## Updating an existing event
+
+### Story
+As an application user
+I want to be able to update an existing events manually
+So I can have store some additional details bound to those events.
+
+As an API consumer
+I want to be able to update existing resources of a given type
+So I can amend content.
+
+### Usage
+```javascript
+var client = new HydraClient();
+var event = client.get("/api/events/1")
+event.eventName = "Some new event name.";
+client.invoke(event.getOperations().filter(op => op.method == "PUT")[0], event);
+```
+
+### Details
+Application needs to be able to modify existing resources. This use case relies on the fact, that 
+the resource is first obtained from the server, amended and sent back, but this is not always true.
+Additionaly, the operation used for the update is taken from the hypermedia controls embedded in the 
+resource and the target method is dicovered with an anti-patter binding it to HTTP protocol.
+Regardles all of these, the communication would look like the example below::
+
+```
+GET /api/events/1
+
+HTTP 200 OK
+```
+```javascript
+{
+    "@id": "/api/events/1",
+    "@type": ["schema:Event", "hydra:Resource"],
+    "eventName": "My brand new event",
+    "eventDescription": "Hope it will work",
+    "startDate": "2017-04-19",
+    "endDate": "2017-04-19",
+    "operation": [
+        {
+            "@type": "hydra:Operation",
+            "title": "Update an existing event",
+            "method": "PUT",
+            "expects": "schema:Event"
+        }
+    ]
+}
+```
+
+```
+PUT /api/events/1
+```
+```javascript
+{
+    "@id": "/api/events/1",
+    "@type": "schema:Event",
+    "eventName": "Some new event name.",
+    "eventDescription": "Hope it will work",
+    "startDate": "2017-04-19",
+    "endDate": "2017-04-19"
+}
+```
+```
+HTTP 204 No Content
+```
+The event should be now updated.
+
+### Considerations
+
+#### What does the term "update" means?
+As mentioned in the [previous use case](/4.obtaining-single-event.md), application is not aware 
+of what kind of data will be provided by the server, thus a simple question may be asked:
+
+*What gets updated?*
+
+The simplest answer would be that whole resource is replaced with new incoming data.
+But it is easy to imagine a situation, where a client may implicitely state what kind of data to 
+include when obtaining a resource, thus server won't know which data to update and which to leave 
+untouched. These considerations could multiplied, thus some explicit directions may be needed.


### PR DESCRIPTION
Yet another use case, when an imaginatory Hydra client updates an event.