### PR TITLE
fix iri template expansion in filter use case

### DIFF
--- a/drafts/use-cases/8.filtering-events.md
+++ b/drafts/use-cases/8.filtering-events.md
@@ -32,7 +32,7 @@ if (events.search) {
 
 ### Details
 The application should be able to filter events with various criteria,
-so the user can narrow number and rellevance of the events displayed.
+so the user can narrow number and relevance of the events displayed.
 This should cover at least a scenario, where user filters events matching
 multiple specific filtering criteria without diving into details
 on how those criteria should be joined (i.e.: alternatives vs logical sum,
@@ -78,7 +78,7 @@ HTTP 200 OK
 ```
 
 ```http
-GET /api/events?schema:eventName=.*test.*
+GET /api/events?eventName=.*test.*
 ```
 
 ```http


### PR DESCRIPTION
it seems that in the snippet we have incorrect expansion of the IRI template

BTW does `hydra:BasicRepresentation` fits here or we should have something different since we use a regular expression?