### PR TITLE
add two more collections: people & venues

### DIFF
--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -15,23 +15,59 @@ There are several possibilities here. One of them would be to use a *@graph* not
         {
             "@id": "/api",
             "@type": "hydra:EntryPoint",
-            "collection": {
-                "@id": "/api/events",
-                "title": "List of events",
-                "@type": "hydra:Collection",
-                "manages": {
-                  "property": "rdf:type",
-                  "object": "schema:Event"
+            "collection": [
+                {
+                    "@id": "/api/events",
+                    "title": "List of events",
+                    "@type": "hydra:Collection",
+                    "manages": {
+                      "property": "rdf:type",
+                      "object": "schema:Event"
+                    },
+                    "operation": [
+                        {
+                           "@type": ["hydra:Operation", "schema:CreateAction"],
+                            "title": "Create new event",
+                            "method": "POST",
+                            "expects": "schema:Event"
+                        }
+                    ]
                 },
-                "operation": [
-                    {
-                       "@type": ["hydra:Operation", "schema:CreateAction"],
-                        "title": "Create new event",
-                        "method": "POST",
-                        "expects": "schema:Event"
-                    }
-                ]
-            }
+                {
+                    "@id": "/api/people",
+                    "title": "List of people",
+                    "@type": "hydra:Collection",
+                    "manages": {
+                      "property": "rdf:type",
+                      "object": "schema:Person"
+                    },
+                    "operation": [
+                        {
+                            "@type": ["hydra:Operation", "schema:CreateAction"],
+                            "title": "Create new person",
+                            "method": "POST",
+                            "expects": "schema:Person"
+                        }
+                    ]
+                },
+                {
+                    "@id": "/api/venues",
+                    "title": "List of venues",
+                    "@type": "hydra:Collection",
+                    "manages": {
+                      "property": "rdf:type",
+                      "object": "schema:Place"
+                    },
+                    "operation": [
+                        {
+                            "@type": ["hydra:Operation", "schema:CreateAction"],
+                            "title": "Create new venue",
+                            "method": "POST",
+                            "expects": "schema:Place"
+                        }
+                    ]
+                }
+            ]
         },
         {
             "rdfs:label": "Some other resource somehow related to the main one."

--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -10,69 +10,63 @@ There are several possibilities here. One of them would be to use a *@graph* not
 
 ```json
 {
-    "@context": "/api/context.jsonld",
-    "@graph": [
+  "@context": "/api/context.jsonld",
+  "@graph": [
+    {
+      "@id": "/api",
+      "@type": "hydra:EntryPoint",
+      "collection": [
         {
-            "@id": "/api",
-            "@type": "hydra:EntryPoint",
-            "collection": [
-                {
-                    "@id": "/api/events",
-                    "title": "List of events",
-                    "@type": "hydra:Collection",
-                    "manages": {
-                      "property": "rdf:type",
-                      "object": "schema:Event"
-                    },
-                    "operation": [
-                        {
-                           "@type": ["hydra:Operation", "schema:CreateAction"],
-                            "title": "Create new event",
-                            "method": "POST",
-                            "expects": "schema:Event"
-                        }
-                    ]
-                },
-                {
-                    "@id": "/api/people",
-                    "title": "List of people",
-                    "@type": "hydra:Collection",
-                    "manages": {
-                      "property": "rdf:type",
-                      "object": "schema:Person"
-                    },
-                    "operation": [
-                        {
-                            "@type": ["hydra:Operation", "schema:CreateAction"],
-                            "title": "Create new person",
-                            "method": "POST",
-                            "expects": "schema:Person"
-                        }
-                    ]
-                },
-                {
-                    "@id": "/api/venues",
-                    "title": "List of venues",
-                    "@type": "hydra:Collection",
-                    "manages": {
-                      "property": "rdf:type",
-                      "object": "schema:Place"
-                    },
-                    "operation": [
-                        {
-                            "@type": ["hydra:Operation", "schema:CreateAction"],
-                            "title": "Create new venue",
-                            "method": "POST",
-                            "expects": "schema:Place"
-                        }
-                    ]
-                }
-            ]
+          "@id": "/api/events",
+          "title": "List of events",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Event"
+          },
+          "operation": {
+            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "title": "Create new event",
+            "method": "POST",
+            "expects": "schema:Event"
+          }
         },
         {
-            "rdfs:label": "Some other resource somehow related to the main one."
+          "@id": "/api/people",
+          "title": "List of people",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Person"
+          },
+          "operation": {
+            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "title": "Create new person",
+            "method": "POST",
+            "expects": "schema:Person"
+          }
+        },
+        {
+          "@id": "/api/venues",
+          "title": "List of venues",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Place"
+          },
+          "operation": {
+            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "title": "Create new venue",
+            "method": "POST",
+            "expects": "schema:Place"
+          }
         }
-    ]
+      ]
+    },
+    {
+      "rdfs:label": "Some other resource somehow related to the main one."
+    }
+  ]
 }
 ```
 

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -31,61 +31,55 @@ HTTP 200 OK
 
 ```json
 {
-    "@context": "/api/context.jsonld",
-    "@id": "/api",
-    "@type": "hydra:EntryPoint",
-    "collection": [
-      {
-          "@id": "/api/events",
-          "title": "List of events",
-          "@type": "hydra:Collection",
-          "manages": {
-            "property": "rdf:type",
-            "object": "schema:Event"
-          },
-          "operation": [
-              {
-                  "@type": ["hydra:Operation", "schema:CreateAction"],
-                  "title": "Create new event",
-                  "method": "POST",
-                  "expects": "schema:Event"
-              }
-          ]
+  "@context": "/api/context.jsonld",
+  "@id": "/api",
+  "@type": "hydra:EntryPoint",
+  "collection": [
+    {
+      "@id": "/api/events",
+      "title": "List of events",
+      "@type": "hydra:Collection",
+      "manages": {
+        "property": "rdf:type",
+        "object": "schema:Event"
       },
-      {
-          "@id": "/api/people",
-          "title": "List of people",
-          "@type": "hydra:Collection",
-          "manages": {
-            "property": "rdf:type",
-            "object": "schema:Person"
-          },
-          "operation": [
-              {
-                  "@type": ["hydra:Operation", "schema:CreateAction"],
-                  "title": "Create new person",
-                  "method": "POST",
-                  "expects": "schema:Person"
-              }
-          ]
-      },
-      {
-          "@id": "/api/venues",
-          "title": "List of venues",
-          "@type": "hydra:Collection",
-          "manages": {
-            "property": "rdf:type",
-            "object": "schema:Place"
-          },
-          "operation": [
-              {
-                  "@type": ["hydra:Operation", "schema:CreateAction"],
-                  "title": "Create new venue",
-                  "method": "POST",
-                  "expects": "schema:Place"
-              }
-          ]
+      "operation": {
+        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "title": "Create new event",
+        "method": "POST",
+        "expects": "schema:Event"
       }
+    },
+    {
+      "@id": "/api/people",
+      "title": "List of people",
+      "@type": "hydra:Collection",
+      "manages": {
+        "property": "rdf:type",
+        "object": "schema:Person"
+      },
+      "operation": {
+        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "title": "Create new person",
+        "method": "POST",
+        "expects": "schema:Person"
+      }
+    },
+    {
+      "@id": "/api/venues",
+      "title": "List of venues",
+      "@type": "hydra:Collection",
+      "manages": {
+        "property": "rdf:type",
+        "object": "schema:Place"
+      },
+      "operation": {
+        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "title": "Create new venue",
+        "method": "POST",
+        "expects": "schema:Place"
+      }
+    }
   ]
 }
 ```

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -34,23 +34,59 @@ HTTP 200 OK
     "@context": "/api/context.jsonld",
     "@id": "/api",
     "@type": "hydra:EntryPoint",
-    "collection": {
-        "@id": "/api/events",
-        "title": "List of events",
-        "@type": "hydra:Collection",
-        "manages": {
-          "property": "rdf:type",
-          "object": "schema:Event"
-        },
-        "operation": [
-            {
-                "@type": ["hydra:Operation", "schema:CreateAction"],
-                "title": "Create new event",
-                "method": "POST",
-                "expects": "schema:Event"
-            }
-        ]
-    }
+    "collection": [
+      {
+          "@id": "/api/events",
+          "title": "List of events",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Event"
+          },
+          "operation": [
+              {
+                  "@type": ["hydra:Operation", "schema:CreateAction"],
+                  "title": "Create new event",
+                  "method": "POST",
+                  "expects": "schema:Event"
+              }
+          ]
+      },
+      {
+          "@id": "/api/people",
+          "title": "List of people",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Person"
+          },
+          "operation": [
+              {
+                  "@type": ["hydra:Operation", "schema:CreateAction"],
+                  "title": "Create new person",
+                  "method": "POST",
+                  "expects": "schema:Person"
+              }
+          ]
+      },
+      {
+          "@id": "/api/venues",
+          "title": "List of venues",
+          "@type": "hydra:Collection",
+          "manages": {
+            "property": "rdf:type",
+            "object": "schema:Place"
+          },
+          "operation": [
+              {
+                  "@type": ["hydra:Operation", "schema:CreateAction"],
+                  "title": "Create new venue",
+                  "method": "POST",
+                  "expects": "schema:Place"
+              }
+          ]
+      }
+  ]
 }
 ```
 


### PR DESCRIPTION
This PR simply adds two more collections to the entry point to make use case closer to datasets on real word eventing services. It also helps exemplify need discussed in #126 and currently implemented in #132 

This EntryPoint should also help with driving implementation of Heracles.ts with respect to distinguishing among collections advertised in the entry point.

In future PRs I will propose various relations betweens events, people and places eg. `schema:location` and `schema:attendee` also providing use case for #134

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/specifications/136)
<!-- Reviewable:end -->
