### PR TITLE
Add Use Case: Creating events indirectly (ie. with PUT)

### DIFF
--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -131,11 +131,13 @@ In such case it would respond with `HTTP/1.1 412 Precondition Failed` status.
 
 #### Advertising connection between collection and created event
 
-Even though the `schema:CreateAction` operation exists within the collection's representation it is not right to assume that
-the newly created event will become part of the collection, ie. it's `"hydra:member"` property. What's more, a single
-operation can have an effect on more that one related resource. For example, in a more elaborate setting, creating a personal
-event can also add that event to the events collection of all participants.
+The `schema:CreateAction` operation is attached to collection's `memberTemplate` which informs the client that the newly
+created event will become part of the collection, ie. it's `"member"` property. However, such operation can have an effect on
+more that one related resource. Building upon this example, in a more elaborate setting creating a personal event could also
+add that event to the events collection of all participants.
 
-There can be many such cases and defining all possibilities is likely outside of Hydra's scope
+There can be many such cases and defining all possible side effect is currently outside of Hydra's scope.
+
+That said, this technique can be used also outside the scope od collections.
 
 [if-none-match]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#Directives

--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -7,8 +7,8 @@ I want allow consumers to construct event identifiers
 So that they can control the URLs.
 
 As an API consumer
-I want to be able to create new resources of a given type
-So I can produce content.
+I want to be able to create new resources idempotently
+So I can retry safely.
 
 ### Usage
 
@@ -30,8 +30,10 @@ var templateVariables = {
 
 var client = new HydraClient();
 var memberTemplate = client.get('http://example.com/events')['hydra:memberTemplate'];
-var operation = memberTemplate.getOperationOfType('http://schema.org/CreateAction')
-    .filter(operation => operation.expects === 'http://schema.org/Event');
+var operation = memberTemplate
+    .getOperationsOfType('http://schema.org/CreateAction')
+    .thatExpect('http://schema.org/Event')
+    .first();
     
 const operationWithTargetExpanded = operation.expandTarget(templateVariables);
 client.invoke(operationWithTargetExpanded, event);
@@ -132,7 +134,7 @@ In such case it would respond with `HTTP/1.1 412 Precondition Failed` status.
 #### Advertising connection between collection and created event
 
 The `schema:CreateAction` operation is attached to collection's `memberTemplate` which informs the client that the newly
-created event will become part of the collection, ie. it's `"member"` property. However, such operation can have an effect on
+created event will become part of the collection, i.e. it's `"member"` property. However, such operation can have an effect on
 more that one related resource. Building upon this example, in a more elaborate setting creating a personal event could also
 add that event to the events collection of all participants.
 

--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -14,22 +14,22 @@ So I can produce content.
 
 ``` js
 var event = {
-    "@context": "/api/context.jsonld",
-    "@type": "schema:Event",
-    "eventName": "My brand new event",
-    "eventDescription": "Hope it will work",
-    "startDate": "2017-04-19",
-    "endDate": "2017-04-19"
+    '@context': '/api/context.jsonld',
+    '@type': 'schema:Event',
+    'eventName': 'My brand new event',
+    'eventDescription': 'Hope it will work',
+    'startDate': '2017-04-19',
+    'endDate': '2017-04-19'
 };
 var templateVariables = {
-    "slug": [
-        "meeting",
-        "with-will"
+    slug: [
+        'meeting',
+        'with-will'
     ]
 };
 
 var client = new HydraClient();
-var memberTemplate = client.get("http://example.com/events")["hydra:memberTemplate"];
+var memberTemplate = client.get('http://example.com/events')['hydra:memberTemplate'];
 var operation = memberTemplate.getOperationOfType('http://schema.org/CreateAction')
     .filter(operation => operation.expects === 'http://schema.org/Event');
     
@@ -122,7 +122,7 @@ instructs the server to reject the update if any representation already exists][
 ``` js
 client.invoke(operationWithTargetExpanded, event, {
     headers: {
-        'If-None-Match': "*"
+        'If-None-Match': '*'
     }
 });
 ```

--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -42,8 +42,8 @@ client.invoke(operationWithTargetExpanded, event);
 ### Details
 
 To create an `Event` using `PUT`, the collection resource has to be linked to the actual target of the operation.
-This linked resource can already have an identifier or be an `IriTemplate` as presented in the above snippet. In this case 
-the representation of the collection resource is not unlike that seen in the [Searching events use case](7.searching-events.md)
+The target of the operation can either be a concrete URL or an `IriTemplate` as shown in the example above. Concrete URLs are 
+out of scope for this use case and might be discussed at a later point in a separate use case document.
 
 ```http
 GET /api/events

--- a/drafts/use-cases/5.1.creating-new-event-indirectly.md
+++ b/drafts/use-cases/5.1.creating-new-event-indirectly.md
@@ -74,10 +74,12 @@ HTTP 200 OK
             }
         ],
         "hydra:operation": [
+          {
             "@type": [ "hydra:Operation", "schema:CreateAction" ],
             "title": "Create new event",
             "method": "PUT",
             "expects": "schema:Event"
+          }
         ]
     }
 }

--- a/drafts/use-cases/5.1.creating-new-event-indirectly.md
+++ b/drafts/use-cases/5.1.creating-new-event-indirectly.md
@@ -1,4 +1,4 @@
-## Creating new event indirectly
+## Creating event with PUT
 
 ### Story
 
@@ -29,8 +29,8 @@ var templateVariables = {
 };
 
 var client = new HydraClient();
-var operation = client.get("http://example.com/events")
-    .getOperationOfType('http://schema.org/CreateAction', /* recursive */ true)
+var memberTemplate = client.get("http://example.com/events")["hydra:memberTemplate"];
+var operation = memberTemplate.getOperationOfType('http://schema.org/CreateAction')
     .filter(operation => operation.expects === 'http://schema.org/Event');
     
 const operationWithTargetExpanded = operation.expandTarget(templateVariables);
@@ -62,7 +62,7 @@ HTTP 200 OK
     },
     "totalItems": 0,
     "members": [ ],
-    "http://example.com/vocab/createEvent": {
+    "hydra:memberTemplate": {
         "@type": "IriTemplate",
         "hydra:template": "http://example.com/api/event{/slug*}",
         "hydra:variableRepresentation": "hydra:BasicRepresentation",
@@ -113,11 +113,21 @@ HTTP/1.1 201 Created
 #### Requesting an existing URI
 
 It is possible that the identifier constructed by filling in `IriTemplate` variables already contains a representation of 
-an event. By the absence of `@id` in the request's payload the server can determine that this request is an attempt to create
-an new resource and not update the existing one. This specification doesn't mandate any correct behaviour on the server part.
+an event. By [definition](https://tools.ietf.org/html/rfc7231#section-4.3.4) of the `PUT` method the server would replace the 
+resource if it already exists. 
 
-An expected response could be `HTTP/1.1 409 Conflict`. However the server can also allow the representation to be replaced
-as in the [Updating Event Use Case](6.updating-event.md) in which case it would response with a 2xx status code.
+If that is not the intended behavior, the client should add `If-None-Match: *` to request headers. The [asterisk value 
+instructs the server to reject the update if any representation already exists][if-none-match]. 
+
+``` js
+client.invoke(operationWithTargetExpanded, event, {
+    headers: {
+        'If-None-Match': "*"
+    }
+});
+```
+
+In such case it would respond with `HTTP/1.1 412 Precondition Failed` status.
 
 #### Advertising connection between collection and created event
 
@@ -127,3 +137,5 @@ operation can have an effect on more that one related resource. For example, in 
 event can also add that event to the events collection of all participants.
 
 There can be many such cases and defining all possibilities is likely outside of Hydra's scope
+
+[if-none-match]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#Directives

--- a/drafts/use-cases/5.1.creating-new-event-indirectly.md
+++ b/drafts/use-cases/5.1.creating-new-event-indirectly.md
@@ -3,8 +3,8 @@
 ### Story
 
 As an API publisher
-I want allow consumers to construct event's identifier
-So that they can control the .
+I want allow consumers to construct event identifiers
+So that they can control the URLs.
 
 As an API consumer
 I want to be able to create new resources of a given type
@@ -33,13 +33,14 @@ var operation = client.get("http://example.com/events")
     .getOperationOfType('http://schema.org/CreateAction', /* recursive */ true)
     .filter(operation => operation.expects === 'http://schema.org/Event');
     
-client.invoke(operation, event, templateVariables);
+const operationWithTargetExpanded = operation.expandTarget(templateVariables);
+client.invoke(operationWithTargetExpanded, event);
 ```
 
 ### Details
 
 To create an `Event` using `PUT`, the collection resource has to be linked to the actual target of the operation.
-This linked object can be a concrete resource or an `IriTemplate` as presented in the above snippet. In this case 
+This linked resource can already have an identifier or be an `IriTemplate` as presented in the above snippet. In this case 
 the representation of the collection resource is not unlike that seen in the [Searching events use case](7.searching-events.md)
 
 ```http
@@ -69,7 +70,7 @@ HTTP 200 OK
             {
                 "@type": "hydra:IriTemplateMapping",
                 "variable": "slug",
-                "property": "xsd:String",
+                "property": "schema:name",
                 "required": true
             }
         ],

--- a/drafts/use-cases/5.1.creating-new-event-indirectly.md
+++ b/drafts/use-cases/5.1.creating-new-event-indirectly.md
@@ -1,0 +1,126 @@
+## Creating new event indirectly
+
+### Story
+
+As an API publisher
+I want allow consumers to construct event's identifier
+So that they can control the .
+
+As an API consumer
+I want to be able to create new resources of a given type
+So I can produce content.
+
+### Usage
+
+``` js
+var event = {
+    "@context": "/api/context.jsonld",
+    "@type": "schema:Event",
+    "eventName": "My brand new event",
+    "eventDescription": "Hope it will work",
+    "startDate": "2017-04-19",
+    "endDate": "2017-04-19"
+};
+var templateVariables = {
+    "slug": [
+        "meeting",
+        "with-will"
+    ]
+};
+
+var client = new HydraClient();
+var operation = client.get("http://example.com/events")
+    .getOperationOfType('http://schema.org/CreateAction', /* recursive */ true)
+    .filter(operation => operation.expects === 'http://schema.org/Event');
+    
+client.invoke(operation, event, templateVariables);
+```
+
+### Details
+
+To create an `Event` using `PUT`, the collection resource has to be linked to the actual target of the operation.
+This linked object can be a concrete resource or an `IriTemplate` as presented in the above snippet. In this case 
+the representation of the collection resource is not unlike that seen in the [Searching events use case](7.searching-events.md)
+
+```http
+GET /api/events
+```
+
+```http
+HTTP 200 OK
+```
+
+``` json
+{
+    "@context": "/api/context.jsonld",
+    "@id": "/api/events",
+    "@type": "hydra:Collection",
+    "manages": {
+      "property": "rdf:type",
+      "object": "schema:Event"
+    },
+    "totalItems": 0,
+    "members": [ ],
+    "http://example.com/vocab/createEvent": {
+        "@type": "IriTemplate",
+        "hydra:template": "http://example.com/api/event{/slug*}",
+        "hydra:variableRepresentation": "hydra:BasicRepresentation",
+        "hydra:mapping": [
+            {
+                "@type": "hydra:IriTemplateMapping",
+                "variable": "slug",
+                "property": "xsd:String",
+                "required": true
+            }
+        ],
+        "hydra:operation": [
+            "@type": [ "hydra:Operation", "schema:CreateAction" ],
+            "title": "Create new event",
+            "method": "PUT",
+            "expects": "schema:Event"
+        ]
+    }
+}
+```
+
+Upon executing the snippet above the following request will be sent to the server:
+
+``` http
+PUT /api/event/meeting/with-will HTTP/1.1
+Host: http://example.com
+```
+
+``` json
+{
+    "@context": "/api/context.jsonld",
+    "@type": "schema:Event",
+    "eventName": "My brand new event",
+    "eventDescription": "Hope it will work",
+    "startDate": "2017-04-19",
+    "endDate": "2017-04-19"
+}
+```
+
+``` http
+HTTP/1.1 201 Created
+```
+
+### Considerations
+
+#### Requesting an existing URI
+
+It is possible that the identifier constructed by filling in `IriTemplate` variables already contains a representation of 
+an event. By the absence of `@id` in the request's payload the server can determine that this request is an attempt to create
+an new resource and not update the existing one. This specification doesn't mandate any correct behaviour on the server part.
+
+An expected response could be `HTTP/1.1 409 Conflict`. However the server can also allow the representation to be replaced
+as in the [Updating Event Use Case](6.updating-event.md) in which case it would response with a 2xx status code.
+
+#### Advertising connection between collection and created event
+
+Even though the `schema:CreateAction` operation exists within the collection's representation it is not right to assume that
+the newly created event will become part of the collection, ie. it's `"hydra:member"` property. What's more, a single
+operation can have an effect on more that one related resource. For example, in a more elaborate setting, creating a personal
+event can also add that event to the events collection of all participants.
+
+There can be many such cases and defining all possibilities is likely outside of Hydra's scope


### PR DESCRIPTION
In this PR I followed the structure we discussed on last call and in issues #3, #118 and #141

I also took the liberty of defining some additional client API elements which allow me to propose mixing an `IriTemplate` and `Operation` in a single request. Please see PR comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/specifications/143)
<!-- Reviewable:end -->
