### PR TITLE
Remove hydra: prefix from use cases

### DIFF
--- a/drafts/use-cases/1.1.security-considerations.md
+++ b/drafts/use-cases/1.1.security-considerations.md
@@ -14,18 +14,18 @@ There are several possibilities here. One of them would be to use a *@graph* not
   "@graph": [
     {
       "@id": "/api",
-      "@type": "hydra:EntryPoint",
+      "@type": "EntryPoint",
       "collection": [
         {
           "@id": "/api/events",
           "title": "List of events",
-          "@type": "hydra:Collection",
+          "@type": "Collection",
           "manages": {
             "property": "rdf:type",
             "object": "schema:Event"
           },
           "operation": {
-            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "@type": ["Operation", "schema:CreateAction"],
             "title": "Create new event",
             "method": "POST",
             "expects": "schema:Event"
@@ -34,13 +34,13 @@ There are several possibilities here. One of them would be to use a *@graph* not
         {
           "@id": "/api/people",
           "title": "List of people",
-          "@type": "hydra:Collection",
+          "@type": "Collection",
           "manages": {
             "property": "rdf:type",
             "object": "schema:Person"
           },
           "operation": {
-            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "@type": ["Operation", "schema:CreateAction"],
             "title": "Create new person",
             "method": "POST",
             "expects": "schema:Person"
@@ -49,13 +49,13 @@ There are several possibilities here. One of them would be to use a *@graph* not
         {
           "@id": "/api/venues",
           "title": "List of venues",
-          "@type": "hydra:Collection",
+          "@type": "Collection",
           "manages": {
             "property": "rdf:type",
             "object": "schema:Place"
           },
           "operation": {
-            "@type": ["hydra:Operation", "schema:CreateAction"],
+            "@type": ["Operation", "schema:CreateAction"],
             "title": "Create new venue",
             "method": "POST",
             "expects": "schema:Place"

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -33,18 +33,18 @@ HTTP 200 OK
 {
   "@context": "/api/context.jsonld",
   "@id": "/api",
-  "@type": "hydra:EntryPoint",
+  "@type": "EntryPoint",
   "collection": [
     {
       "@id": "/api/events",
       "title": "List of events",
-      "@type": "hydra:Collection",
+      "@type": "Collection",
       "manages": {
         "property": "rdf:type",
         "object": "schema:Event"
       },
       "operation": {
-        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "@type": ["Operation", "schema:CreateAction"],
         "title": "Create new event",
         "method": "POST",
         "expects": "schema:Event"
@@ -53,13 +53,13 @@ HTTP 200 OK
     {
       "@id": "/api/people",
       "title": "List of people",
-      "@type": "hydra:Collection",
+      "@type": "Collection",
       "manages": {
         "property": "rdf:type",
         "object": "schema:Person"
       },
       "operation": {
-        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "@type": ["Operation", "schema:CreateAction"],
         "title": "Create new person",
         "method": "POST",
         "expects": "schema:Person"
@@ -68,13 +68,13 @@ HTTP 200 OK
     {
       "@id": "/api/venues",
       "title": "List of venues",
-      "@type": "hydra:Collection",
+      "@type": "Collection",
       "manages": {
         "property": "rdf:type",
         "object": "schema:Place"
       },
       "operation": {
-        "@type": ["hydra:Operation", "schema:CreateAction"],
+        "@type": ["Operation", "schema:CreateAction"],
         "title": "Create new venue",
         "method": "POST",
         "expects": "schema:Place"
@@ -93,22 +93,22 @@ With this details, client application is aware of two possible operations that c
 - POST an event
 
 It is possible for a rich UI application with some fancy logic that would takes all
-GET operations returning *hydra:Collection* and displays them in a main menu.
+GET operations returning *Collection* and displays them in a main menu.
 
 ### Considerations
 
 #### RDFS entailment and OWL Reasoning capabilities
 Another thing is how far the client should be pushed into the reasoning process.
 In the example above, both operations have their type explicitely expressed with *"@type"* keyword.
-But in RDFS environment, it is possible to use only *hydra:method* and *hydra:expects* predicates,
+But in RDFS environment, it is possible to use only *method* and *expects* predicates,
 which is fully legal as the entailment process would extend the resource */events* with additional
 statement (in Turtle):
 
 ```ttl
-[] a hydra:Operation .
+[] a Operation .
 ```
 
-This is due to fact that Hydra Core Vocabulary provides an *rdfs:domain* for *hydra:method* .
+This is due to fact that Hydra Core Vocabulary provides an *rdfs:domain* for *method* .
 Unfortunately, many clients, especially browser based, won't use that process of entailment,
 thus an explicit statement should appear so the client can easily discover all the operations.
 

--- a/drafts/use-cases/1.entry-point.md
+++ b/drafts/use-cases/1.entry-point.md
@@ -105,7 +105,7 @@ which is fully legal as the entailment process would extend the resource */event
 statement (in Turtle):
 
 ```ttl
-[] a Operation .
+[] a hydra:Operation .
 ```
 
 This is due to fact that Hydra Core Vocabulary provides an *rdfs:domain* for *method* .

--- a/drafts/use-cases/3.1.extensions-considerations.md
+++ b/drafts/use-cases/3.1.extensions-considerations.md
@@ -32,7 +32,7 @@ Again, named graphs would come in handy in this situation, i.e.:
                     "@id": "/api/events",
                     "operation": [
                         {
-                            "@type": ["hydra:Operation", "schema:CreateAction"],
+                            "@type": ["Operation", "schema:CreateAction"],
                             "title": "Create new event",
                             "method": "POST",
                             "expects": "schema:Event"

--- a/drafts/use-cases/3.obtaining-events.md
+++ b/drafts/use-cases/3.obtaining-events.md
@@ -35,7 +35,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "manages": {
       "property": "rdf:type",
       "object": "schema:Event"

--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -29,7 +29,7 @@ var templateVariables = {
 };
 
 var client = new HydraClient();
-var memberTemplate = client.get('http://example.com/events')['hydra:memberTemplate'];
+var memberTemplate = client.get('http://example.com/events')['memberTemplate'];
 var operation = memberTemplate
     .getOperationsOfType('http://schema.org/CreateAction')
     .thatExpect('http://schema.org/Event')
@@ -57,28 +57,28 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "manages": {
       "property": "rdf:type",
       "object": "schema:Event"
     },
     "totalItems": 0,
     "members": [ ],
-    "hydra:memberTemplate": {
+    "memberTemplate": {
         "@type": "IriTemplate",
-        "hydra:template": "http://example.com/api/event{/slug*}",
-        "hydra:variableRepresentation": "hydra:BasicRepresentation",
-        "hydra:mapping": [
+        "template": "http://example.com/api/event{/slug*}",
+        "variableRepresentation": "BasicRepresentation",
+        "mapping": [
             {
-                "@type": "hydra:IriTemplateMapping",
+                "@type": "IriTemplateMapping",
                 "variable": "slug",
                 "property": "schema:name",
                 "required": true
             }
         ],
-        "hydra:operation": [
+        "operation": [
           {
-            "@type": [ "hydra:Operation", "schema:CreateAction" ],
+            "@type": [ "Operation", "schema:CreateAction" ],
             "title": "Create new event",
             "method": "PUT",
             "expects": "schema:Event"

--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -29,7 +29,7 @@ var templateVariables = {
 };
 
 var client = new HydraClient();
-var memberTemplate = client.get('http://example.com/events')['memberTemplate'];
+var memberTemplate = client.get('http://example.com/events').memberTemplate;
 var operation = memberTemplate
     .getOperationsOfType('http://schema.org/CreateAction')
     .thatExpect('http://schema.org/Event')

--- a/drafts/use-cases/6.updating-event.md
+++ b/drafts/use-cases/6.updating-event.md
@@ -37,14 +37,14 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events/1",
-    "@type": ["schema:Event", "hydra:Resource"],
+    "@type": ["schema:Event", "Resource"],
     "eventName": "My brand new event",
     "eventDescription": "Hope it will work",
     "startDate": "2017-04-19",
     "endDate": "2017-04-19",
     "operation": [
         {
-            "@type": ["hydra:Operation", "schema:ReplaceAction"],
+            "@type": ["Operation", "schema:ReplaceAction"],
             "title": "Update an existing event",
             "method": "PUT",
             "expects": "schema:Event"

--- a/drafts/use-cases/6.updating-event.md
+++ b/drafts/use-cases/6.updating-event.md
@@ -37,7 +37,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events/1",
-    "@type": ["schema:Event", "Resource"],
+    "@type": ["schema:Event"],
     "eventName": "My brand new event",
     "eventDescription": "Hope it will work",
     "startDate": "2017-04-19",

--- a/drafts/use-cases/7.searching-events.md
+++ b/drafts/use-cases/7.searching-events.md
@@ -48,7 +48,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "manages": {
       "property": "rdf:type",
       "object": "schema:Event"
@@ -65,13 +65,13 @@ HTTP 200 OK
     ],
     "search": {
         "@type": "IriTemplate",
-        "hydra:template": "http://example.com/api/events{?search}",
-        "hydra:variableRepresentation": "hydra:BasicRepresentation",
-        "hydra:mapping": [
+        "template": "http://example.com/api/events{?search}",
+        "variableRepresentation": "BasicRepresentation",
+        "mapping": [
             {
-                "@type": "hydra:IriTemplateMapping",
+                "@type": "IriTemplateMapping",
                 "variable": "search",
-                "property": "hydra:freetextQuery",
+                "property": "freetextQuery",
                 "required": true
             }
         ]
@@ -91,7 +91,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events?search=some text",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "totalItems": 1,
     "members": [
         {
@@ -145,13 +145,13 @@ HTTP 200 OK
     ],
     "search": {
         "@type": "IriTemplate",
-        "hydra:template": "http://example.com/api/events{?search}",
-        "hydra:variableRepresentation": "hydra:BasicRepresentation",
-        "hydra:mapping": [
+        "template": "http://example.com/api/events{?search}",
+        "variableRepresentation": "BasicRepresentation",
+        "mapping": [
             {
-                "@type": "hydra:IriTemplateMapping",
+                "@type": "IriTemplateMapping",
                 "variable": "search",
-                "property": "hydra:freetextQuery",
+                "property": "freetextQuery",
                 "required": true
             }
         ]
@@ -165,7 +165,7 @@ Following analogy of other predefined links, like *first* for collections,
 templated links should be used as predicates:
 
 ```turtle
-</api/events> hydra:search </api-doc/events#search-iri-template> .
+</api/events> search </api-doc/events#search-iri-template> .
 ```
 
 Above's example of a triple with a templated link
@@ -177,7 +177,7 @@ of fake namespaces.
 
 Also a location of the template itself within the graph is not clear.
 The example above puts it as a related resource of the
-*hydra:search* predicate, but only to fill the gap as
+*search* predicate, but only to fill the gap as
 there is no other resource that could be used to
 build up a valid statement.
 Also this seems compliant (again by analogy) to simple scenario

--- a/drafts/use-cases/8.filtering-events.md
+++ b/drafts/use-cases/8.filtering-events.md
@@ -51,7 +51,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": "/api/events",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "manages": {
       "property": "rdf:type",
       "object": "schema:Event"
@@ -68,11 +68,11 @@ HTTP 200 OK
     ],
     "search": {
         "@type": "IriTemplate",
-        "hydra:template": "http://example.com/api/events{?eventName}",
-        "hydra:variableRepresentation": "hydra:BasicRepresentation",
-        "hydra:mapping": [
+        "template": "http://example.com/api/events{?eventName}",
+        "variableRepresentation": "BasicRepresentation",
+        "mapping": [
             {
-                "@type": "hydra:IriTemplateMapping",
+                "@type": "IriTemplateMapping",
                 "variable": "eventName",
                 "property": "http://schema.org/name",
                 "required": false
@@ -94,7 +94,7 @@ HTTP 200 OK
 {
     "@context": "/api/context.jsonld",
     "@id": " /api/events?schema:eventName=.*test.*",
-    "@type": "hydra:Collection",
+    "@type": "Collection",
     "totalItems": 1,
     "members": [
         {
@@ -122,7 +122,7 @@ into multiple parts with a pager and a page-size options available.
 
 From technical point of view, this behavior could be achieved
 with special purpose virtual predicates
-(i.e.:  imaginatory hydra:limit and hydra:offset).
+(i.e.:  imaginatory limit and offset).
 The argument against is that these are not direct properties
 of resources being filtered.
 Supporting argument would be that similar approach is used

--- a/drafts/use-cases/9.adding-existing-resources-to-collections.md
+++ b/drafts/use-cases/9.adding-existing-resources-to-collections.md
@@ -38,7 +38,7 @@ HTTP 200 OK
     "collection": {
       "@id": "/api/events/1/attendees",
       "title": "List of attendees",
-      "@type": "hydra:Collection",
+      "@type": "Collection",
       "manages": [
         {
           "property": "rdf:type",
@@ -50,7 +50,7 @@ HTTP 200 OK
         }
       ],
       "operation": {
-        "@type": ["hydra:Operation", "schema:AddAction"],
+        "@type": ["Operation", "schema:AddAction"],
         "title": "Add event attendee",
         "method": "LINK",
         "expects": "schema:Person"
@@ -81,7 +81,7 @@ HTTP 200 OK
     "collection": {
       "@id": "/api/people/1/attended",
       "title": "List of attended events",
-      "@type": "hydra:Collection",
+      "@type": "Collection",
       "manages": [
         {
           "property": "rdf:type",
@@ -93,7 +93,7 @@ HTTP 200 OK
         }
       ],
       "operation": {
-        "@type": ["hydra:Operation", "schema:AddAction"],
+        "@type": ["Operation", "schema:AddAction"],
         "title": "Add attended event",
         "method": "LINK",
         "expects": "schema:Event"


### PR DESCRIPTION
The only exceptions are turtle snippets and two terms mentioned which aren't actually part of the vocab.

I'm actually not sure whether we want to keep the `hydra:` prefix in text usage but decided to remove all of them for consistency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/specifications/151)
<!-- Reviewable:end -->
