### PR TITLE
actions with explicit target

### DIFF
--- a/drafts/use-cases/5.1.creating-event-with-put.md
+++ b/drafts/use-cases/5.1.creating-event-with-put.md
@@ -22,28 +22,26 @@ var event = {
     'startDate': '2017-04-19',
     'endDate': '2017-04-19'
 };
-var templateVariables = {
-    slug: [
-        'meeting',
-        'with-will'
-    ]
-};
 
 var client = new HydraClient();
-var memberTemplate = client.get('http://example.com/events').memberTemplate;
-var operation = memberTemplate
-    .getOperationsOfType('http://schema.org/CreateAction')
+var operation = client.get('http://example.com/events');
+    .getOperationsOfType('http://schema.org/AddAction')
     .thatExpect('http://schema.org/Event')
     .first();
+if (operation) {
+  var templateVariables = {
+      'schema:name' : 'meeting with-will'
+  };
+  const operationWithTargetExpanded = operation.expandTarget(templateVariables);
+  client.invoke(operationWithTargetExpanded, event);
+}
 
-const operationWithTargetExpanded = operation.expandTarget(templateVariables);
-client.invoke(operationWithTargetExpanded, event);
 ```
 
 
 ## Details
 
-To create an `Event` using `PUT`, the collection resource has to be linked to the actual target of the operation.
+To create an `Event` using `PUT`, the collection resource has to advertise an action with a target for the operation.
 The target of the operation can either be a concrete URL or an `IriTemplate` as shown in the example above. Concrete URLs are
 out of scope for this use case and might be discussed at a later point in a separate use case document.
 
@@ -66,26 +64,24 @@ HTTP 200 OK
     },
     "totalItems": 0,
     "members": [ ],
-    "memberTemplate": {
-        "@type": "IriTemplate",
-        "template": "http://example.com/api/event{/slug*}",
-        "variableRepresentation": "BasicRepresentation",
-        "mapping": [
-            {
-                "@type": "IriTemplateMapping",
-                "variable": "slug",
-                "property": "schema:name",
-                "required": true
-            }
-        ],
-        "operation": [
-          {
-            "@type": [ "Operation", "schema:CreateAction" ],
-            "title": "Create new event",
-            "method": "PUT",
-            "expects": "schema:Event"
-          }
-        ]
+    "schema:potentialAction": {
+        "@type": "schema:AddAction",
+        "title": "add an event to collection",
+        "method": "PUT",
+        "expects": "schema:Event",
+        "schema:target": {
+            "@type": "IriTemplate",
+            "template": "http://example.com/api/event{/slug*}",
+            "variableRepresentation": "BasicRepresentation",
+            "mapping": [
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "slug",
+                    "property": "schema:name",
+                    "required": true
+                }
+            ]
+        }
     }
 }
 ```
@@ -136,7 +132,7 @@ In such case it would respond with `HTTP/1.1 412 Precondition Failed` status.
 
 ### Advertising connection between collection and created event
 
-The `schema:CreateAction` operation is attached to collection's `memberTemplate` which informs the client that the newly
+The `schema:AddAction` operation is advertised on the collection itself, which informs the client that the newly
 created event will become part of the collection, i.e. it's `"member"` property. However, such operation can have an effect on
 more that one related resource. Building upon this example, in a more elaborate setting creating a personal event could also
 add that event to the events collection of all participants.

--- a/drafts/use-cases/7.searching-events.md
+++ b/drafts/use-cases/7.searching-events.md
@@ -15,20 +15,14 @@ So I can find those interesting to me.
 
 ```javascript
 var client = new HydraClient();
-var collection = client.get("/api/events");
-if (colletion.search) {
-    var filter = {};
-    for (let mapping of collection.search.mappings) {
-        filter[mapping.variable] = "some text";
-    }
-
-    var query = urlTemplate
-        .parse(collection.search.template)
-        .expand(filter);
-    var data = client.get(query);
-    for (var member of data.members) {
-        // do something with the _member_, i.e. display it
-    }
+var operation = client.get("http://example.com/api/events")
+    .getOperationOfType('http://schema.org/SearchAction');
+if (operation) {
+  var templateVariables = {
+    hydra.freetextQuery: "some text"
+  }
+const operationWithTargetExpanded = operation.expandTarget(templateVariables);
+client.invoke(operationWithTargetExpanded);
 }
 ```
 
@@ -68,18 +62,21 @@ HTTP 200 OK
             "endDate": "2017-04-19"
         }
     ],
-    "search": {
-        "@type": "IriTemplate",
-        "template": "http://example.com/api/events{?search}",
-        "variableRepresentation": "BasicRepresentation",
-        "mapping": [
-            {
-                "@type": "IriTemplateMapping",
-                "variable": "search",
-                "property": "freetextQuery",
-                "required": true
-            }
-        ]
+    "schema:potentialAction": {
+        "@type": "schema:SearchAction",
+        "schema:target": {
+            "@type": "IriTemplate",
+            "template": "http://example.com/api/events{?search}",
+            "variableRepresentation": "BasicRepresentation",
+            "mapping": [
+                {
+                    "@type": "IriTemplateMapping",
+                    "variable": "search",
+                    "property": "freetextQuery",
+                    "required": true
+                }
+            ]
+        }
     }
 }
 ```
@@ -102,91 +99,10 @@ HTTP 200 OK
         {
             "@id": "/api/events/1",
             "eventName": "Event 1",
-            "eventDescription": "Some event having a search phrase",
+            "eventDescription": "Some event having a search phrase: some text",
             "startDate": "2017-04-19",
             "endDate": "2017-04-19"
         }
     ]
 }
 ```
-
-
-## Considerations
-
-### How the client would be informed of the search possibility
-There are two main sources of that information which can enable client
-with a search feature:
-
-- API documentation
-- hypermedia controls
-
-Unfortunately, current specification does not clearly state,
-how the templated link should be embedded in the payload of both.
-There is an example of a templated link using a special
-purpose *freetextQuery* property that can be used for search.
-There is also a special purpose templated link *search*,
-but again it is unclear on how it should be used.
-Possible payload for hypermedia control would look like this:
-
-```http
-GET /api/events
-```
-
-```http
-HTTP 200 OK
-```
-
-```json
-{
-    "@context": "/api/context.jsonld",
-    "@id": "/api/events",
-    "totalItems": 1,
-    "members": [
-        {
-            "@id": "/api/events/1",
-            "eventName": "Event 1",
-            "eventDescription": "Some event 1",
-            "startDate": "2017-04-19",
-            "endDate": "2017-04-19"
-        }
-    ],
-    "search": {
-        "@type": "IriTemplate",
-        "template": "http://example.com/api/events{?search}",
-        "variableRepresentation": "BasicRepresentation",
-        "mapping": [
-            {
-                "@type": "IriTemplateMapping",
-                "variable": "search",
-                "property": "freetextQuery",
-                "required": true
-            }
-        ]
-    }
-}
-```
-
-
-### Templated link usage
-
-Following analogy of other predefined links, like *first* for collections,
-templated links should be used as predicates:
-
-```turtle
-</api/events> search </api-doc/events#search-iri-template> .
-```
-
-The example above of a triple with a templated link
-seems inconvenient as in order to define a custom
-templated link, one should create a separate resource.
-IRI of that resource shall be nicely foldable to QIri form
-in order to improve readability, resulting in a number
-of fake namespaces.
-
-Also a location of the template itself within the graph is not clear.
-The example above puts it as a related resource of the
-*search* predicate, but only to fill the gap as
-there is no other resource that could be used to
-build up a valid statement.
-Also this seems compliant (again by analogy) to simple scenario
-with *first* predicate, where the related resource is another collection page.


### PR DESCRIPTION
obviously **NOT READY TO MERGE**

This PR serves as starting point for considering actions/operations with **explicit target**, I reuse terms from `schema:` namespace - *schema:potentialAction* & *schema:target* just because they seem to have same purpose and we already use other terms from that namespace.

I would also suggest not to focus on the client pseudo code and update it with Heracles.ts based code as the reference implementation of the client progresses.

As discussed in on of the previous issues, it seems that we have something like:
 ```ttl
hydra:operation rdfs:subPropertyOf schema:potentialAction .
hydra:Operation rdfs:subClassOf schema:Action .
```
so more specific `hydra:operation` implies the target of referenced `hydra:Operation`, while `schema:potentialAction` leaves it to `schema:Action` to make the target explicit via `schema:target`.