### PR TITLE
Added hydra:memberTemplate

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -34,6 +34,8 @@
     "operation": "hydra:operation",
     "Collection": "hydra:Collection",
     "member": { "@id": "hydra:member", "@type": "@id" },
+    "manages": { "@id": "hydra:manages", "@type": "@id" },
+    "subject": { "@id": "hydra:subject", "@type": "@id" },
     "search": "hydra:search",
     "freetextQuery": "hydra:freetextQuery",
     "view": { "@id": "hydra:view", "@type": "@id" },
@@ -43,6 +45,7 @@
     "last": { "@id": "hydra:last", "@type": "@id" },
     "next": { "@id": "hydra:next", "@type": "@id" },
     "previous": { "@id": "hydra:previous", "@type": "@id" },
+	"memberTemplate": { "@id": "hydra:memberTemplate", "@type": "@id" },
     "Link": "hydra:Link",
     "TemplatedLink": "hydra:TemplatedLink",
     "IriTemplate": "hydra:IriTemplate",
@@ -166,7 +169,7 @@
       "@id": "hydra:property",
       "@type": "rdf:Property",
       "label": "property",
-      "comment": "A property",
+      "comment": "A property, either supported by a class or described by a collection",
       "range": "rdf:Property",
       "vs:term_status": "testing"
     },
@@ -300,6 +303,27 @@
       "vs:term_status": "testing"
     },
     {
+      "@id": "hydra:collection",
+      "@type": "hydra:Link",
+      "label": "collection",
+      "comment": "Allows to link multiple collections to an owning resource.",
+      "domain": "hydra:Collection",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:manages",
+      "label": "manages",
+      "comment": "Semantics of each member provided by the collection.",
+      "domain": "hydra:Collection",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:subject",
+      "label": "subject",
+      "comment": "Provides details on on the resource being a subject in relation described by the collection.",
+      "vs:term_status": "testing"
+    },
+    {
       "@id": "hydra:member",
       "@type": "hydra:Link",
       "label": "member",
@@ -386,6 +410,15 @@
       "range": "xsd:string",
       "vs:term_status": "testing"
     },
+	{
+	  "@id": "hydra:memberTemplate",
+	  "@type": "rdf:Property",
+	  "label": "collection member IRI template",
+	  "comment": "An IRI template of a collection's member.",
+	  "range": "hydra:IriTemplate",
+	  "domain": "hydra:Collection",
+	  "vs:term_status": "testing"
+	},
     {
       "@id": "hydra:TemplatedLink",
       "@type": "hydra:Class",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -34,8 +34,6 @@
     "operation": "hydra:operation",
     "Collection": "hydra:Collection",
     "member": { "@id": "hydra:member", "@type": "@id" },
-    "manages": { "@id": "hydra:manages", "@type": "@id" },
-    "subject": { "@id": "hydra:subject", "@type": "@id" },
     "search": "hydra:search",
     "freetextQuery": "hydra:freetextQuery",
     "view": { "@id": "hydra:view", "@type": "@id" },
@@ -169,7 +167,7 @@
       "@id": "hydra:property",
       "@type": "rdf:Property",
       "label": "property",
-      "comment": "A property, either supported by a class or described by a collection",
+      "comment": "A property",
       "range": "rdf:Property",
       "vs:term_status": "testing"
     },
@@ -300,27 +298,6 @@
       "subClassOf": "hydra:Resource",
       "label": "Collection",
       "comment": "A collection holding references to a number of related resources.",
-      "vs:term_status": "testing"
-    },
-    {
-      "@id": "hydra:collection",
-      "@type": "hydra:Link",
-      "label": "collection",
-      "comment": "Allows to link multiple collections to an owning resource.",
-      "domain": "hydra:Collection",
-      "vs:term_status": "testing"
-    },
-    {
-      "@id": "hydra:manages",
-      "label": "manages",
-      "comment": "Semantics of each member provided by the collection.",
-      "domain": "hydra:Collection",
-      "vs:term_status": "testing"
-    },
-    {
-      "@id": "hydra:subject",
-      "label": "subject",
-      "comment": "Provides details on on the resource being a subject in relation described by the collection.",
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -43,7 +43,7 @@
     "last": { "@id": "hydra:last", "@type": "@id" },
     "next": { "@id": "hydra:next", "@type": "@id" },
     "previous": { "@id": "hydra:previous", "@type": "@id" },
-    "memberTemplate": { "@id": "hydra:memberTemplate", "@type": "@id" },
+    "memberTemplate": "hydra:memberTemplate",
     "Link": "hydra:Link",
     "TemplatedLink": "hydra:TemplatedLink",
     "IriTemplate": "hydra:IriTemplate",
@@ -391,7 +391,7 @@
       "@id": "hydra:memberTemplate",
       "@type": "rdf:Property",
       "label": "collection member IRI template",
-      "comment": "An IRI template of a collection's member.",
+      "comment": "A IRI template to directly access collection members.",
       "range": "hydra:IriTemplate",
       "domain": "hydra:Collection",
       "vs:term_status": "testing"

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -45,7 +45,7 @@
     "last": { "@id": "hydra:last", "@type": "@id" },
     "next": { "@id": "hydra:next", "@type": "@id" },
     "previous": { "@id": "hydra:previous", "@type": "@id" },
-	"memberTemplate": { "@id": "hydra:memberTemplate", "@type": "@id" },
+    "memberTemplate": { "@id": "hydra:memberTemplate", "@type": "@id" },
     "Link": "hydra:Link",
     "TemplatedLink": "hydra:TemplatedLink",
     "IriTemplate": "hydra:IriTemplate",
@@ -410,15 +410,15 @@
       "range": "xsd:string",
       "vs:term_status": "testing"
     },
-	{
-	  "@id": "hydra:memberTemplate",
-	  "@type": "rdf:Property",
-	  "label": "collection member IRI template",
-	  "comment": "An IRI template of a collection's member.",
-	  "range": "hydra:IriTemplate",
-	  "domain": "hydra:Collection",
-	  "vs:term_status": "testing"
-	},
+    {
+      "@id": "hydra:memberTemplate",
+      "@type": "rdf:Property",
+      "label": "collection member IRI template",
+      "comment": "An IRI template of a collection's member.",
+      "range": "hydra:IriTemplate",
+      "domain": "hydra:Collection",
+      "vs:term_status": "testing"
+    },
     {
       "@id": "hydra:TemplatedLink",
       "@type": "hydra:Class",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -389,7 +389,7 @@
     },
     {
       "@id": "hydra:memberTemplate",
-      "@type": "rdf:Property",
+      "@type": "hydra:TemplatedLink",
       "label": "collection member IRI template",
       "comment": "A IRI template to directly access collection members.",
       "range": "hydra:IriTemplate",

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -858,17 +858,16 @@
   </section>
   
   <section>
-    <h3>Collection members' link template</h3>
+    <h3>Collection member link template</h3>
 	
-	<p>In some circumstances it is useful to give a direct access to collection's
-	  members by providing an instruction on how to construct an URL by the client.
-	  This URL then can be used either to obtain member's details or to update it,
-	  i.e. as a result of some batch processing. In order to support this scenario
-	  Hydra introduces <i>memberTemplate</i> link that directly binds an owning
-	  <i>Collection</i> with the <i>IriTemplate</i>.</p>
+	<p>In some circumstances it is useful to give a direct access to a collection's
+	  members by providing an instruction on how to construct an URL to the client.
+	  This URL then can be used either to obtain member's details or to update it.
+      In order to support this scenario Hydra introduces <i>memberTemplate</i> property
+      to describe the URL structure of collection members with an <i>IriTemplate</i>.</p>
 
 	<pre class="example nohighlight" data-transform="updateExample"
-         title="Collection with a direct access to it's members via an IRI template member link.">
+         title="Collection with a direct access to its members via an IRI template">
       <!--
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
@@ -876,32 +875,32 @@
         "@type": "Collection",
         "totalItems": "329",
         "member": [
-          ####... a subset of the members of the Collection ...####
+          ####... members of the Collection ...####
         ],
-		"memberTemplate": {
-		  "@type": "IriTemplate",
-		  "template": "http://api.example/com/users{?userName}",
-		  "variableRepresentation": "hydra:BasicRepresentation",
-		  "mapping": {
-		    "@type": "IriTemplateMapping",
-			"variable": "userName",
-			"property": "http://vocab.example.com/userName",
-			"required": true
-		  },
-		  "operation": {
-		    "@type": "Operation",
-			"method": "PUT",
-			"expects": "http://vocab.example.com/User"
-		  }
-		}
+        "memberTemplate": {
+          "@type": "IriTemplate",
+          "template": "http://api.example/com/users/{userName}",
+          "variableRepresentation": "hydra:BasicRepresentation",
+          "mapping": {
+            "@type": "IriTemplateMapping",
+            "variable": "userName",
+            "property": "http://api.example.com/vocab#userName",
+            "required": true
+          },
+          "operation": {
+            "@type": "Operation",
+            "method": "PUT",
+            "expects": "http://api.example.com/vocab#User"
+          }
+        }
       }
       -->
     </pre>
 
-	<p>In the example above, the API exposes a direct access to the collection of 
-	  users by providing an IRI template that expects a user name property making 
-	  it a fully functional link. There is also an operation declared that enables 
-	  client to update a given user with an HTTP <i>PUT</i> method.</p>
+	<p>In the example above, the API describes how to directly access a member of the
+      <i>/users</i> collection through an IRI template requiring the user name.
+      There is also an operation that tels a client that it can use HTTP put on
+      those resources.</p>
   </section>
 
   <section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -859,14 +859,14 @@
   
   <section>
     <h3>Collection member link template</h3>
-	
-	<p>In some circumstances it is useful to give a direct access to a collection's
-	  members by providing an instruction on how to construct an URL to the client.
-	  This URL then can be used either to obtain member's details or to update it.
-      In order to support this scenario Hydra introduces <i>memberTemplate</i> property
+
+    <p>In some circumstances it is useful to give a direct access to a collection's
+      members by providing an instruction on how to construct an URL to the client.
+      This URL then can be used either to obtain member's details or to update it.
+      In order to support this scenario Hydra provides the <i>memberTemplate</i> property
       to describe the URL structure of collection members with an <i>IriTemplate</i>.</p>
 
-	<pre class="example nohighlight" data-transform="updateExample"
+    <pre class="example nohighlight" data-transform="updateExample"
          title="Collection with a direct access to its members via an IRI template">
       <!--
       {
@@ -897,7 +897,7 @@
       -->
     </pre>
 
-	<p>In the example above, the API describes how to directly access a member of the
+    <p>In the example above, the API describes how to directly access a member of the
       <i>/users</i> collection through an IRI template requiring the user name.
       There is also an operation that tels a client that it can use HTTP put on
       those resources.</p>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -856,6 +856,53 @@
       -->
     </pre>
   </section>
+  
+  <section>
+    <h3>Collection members' link template</h3>
+	
+	<p>In some circumstances it is useful to give a direct access to collection's
+	  members by providing an instruction on how to construct an URL by the client.
+	  This URL then can be used either to obtain member's details or to update it,
+	  i.e. as a result of some batch processing. In order to support this scenario
+	  Hydra introduces <i>memberTemplate</i> link that directly binds an owning
+	  <i>Collection</i> with the <i>IriTemplate</i>.</p>
+
+	<pre class="example nohighlight" data-transform="updateExample"
+         title="Collection with a direct access to it's members via an IRI template member link.">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/users",
+        "@type": "Collection",
+        "totalItems": "329",
+        "member": [
+          ####... a subset of the members of the Collection ...####
+        ],
+		"memberTemplate": {
+		  "@type": "IriTemplate",
+		  "template": "http://api.example/com/users{?userName}",
+		  "variableRepresentation": "hydra:BasicRepresentation",
+		  "mapping": {
+		    "@type": "IriTemplateMapping",
+			"variable": "userName",
+			"property": "http://vocab.example.com/userName",
+			"required": true
+		  },
+		  "operation": {
+		    "@type": "Operation",
+			"method": "PUT",
+			"expects": "http://vocab.example.com/User"
+		  }
+		}
+      }
+      -->
+    </pre>
+
+	<p>In the example above, the API exposes a direct access to the collection of 
+	  users by providing an IRI template that expects a user name property making 
+	  it a fully functional link. There is also an operation declared that enables 
+	  client to update a given user with an HTTP <i>PUT</i> method.</p>
+  </section>
 
   <section>
     <h3>Description of HTTP Status Codes and Errors</h3>


### PR DESCRIPTION
This pull request adds a hydra:memberTemplate discussed in #16 predicate to the vocabulary with a piece of documentation to the spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/specifications/158)
<!-- Reviewable:end -->
