### PR TITLE
Specification change to cover the issue

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -314,6 +314,11 @@
       <code>comments</code> property in the following example is intended
       to be dereferenced.</p>
 
+    <p class="note">It is recommended to dereference resources that are
+      within API's domain. This may prevent possible issues with cross-site
+      scripting or obtaining meaningless resources. Still, there is no formal
+      prohibition of dereferencing <i>untyped</i> links, i.e. <i>rdf:seeAlso</i>.</p>
+
     <pre class="example nohighlight" data-transform="updateExample"
          title="Using a property defined to be a hyperlink">
       <!--


### PR DESCRIPTION
Added a proper paragraphs recommending dereferencing untyped links from the API's domain. No other vocabulary constructs were presented.