### PR TITLE
Should returns and statusCodes be removed to avoid tight coupling?

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -555,9 +555,12 @@
 
     <p>Keep in mind that operations specified in an <i>ApiDocumentation</i>
       may fail at runtime as either resources or the <i>ApiDocumentation</i>
-      itself have changed since they have been retrieved. A simple strategy
-      to try to recover from such an error is to reload the
-      <i>ApiDocumentation</i>.</p>
+      itself have changed since they have been retrieved. Also operation details
+      like <i>hydra:returns</i> or <i>hydra:statusCodes</i> may vary at runtime,
+      thus these interpreted at runtime. A simple strategy to try to recover from
+      such a situation is to reload the <i>ApiDocumentation</i> and redo all
+      operations that were based on the <i>ApiDocumentation</i> (or at least those
+      that lead to the current failure).</p>
 
     <p class="issue">Describe the various properties of an operation.</p>
   </section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -556,11 +556,14 @@
     <p>Keep in mind that operations specified in an <i>ApiDocumentation</i>
       may fail at runtime as either resources or the <i>ApiDocumentation</i>
       itself have changed since they have been retrieved. Also operation details
-      like <i>hydra:returns</i> or <i>hydra:possibleStatus</i> may vary at runtime,
-      thus these interpreted at runtime. A simple strategy to try to recover from
-      such a situation is to reload the <i>ApiDocumentation</i> and redo all
-      operations that were based on the <i>ApiDocumentation</i> (or at least those
-      that lead to the current failure).</p>
+      like <i>returns</i> or <i>possibleStatus</i> may vary at runtime,
+      which means client SHOULD verify received payloads at runtime.
+      A simple strategy to try to recover from such a situation is to reload
+      the <i>ApiDocumentation</i> and redo all pre-computations that were
+      based on the <i>ApiDocumentation</i> (or at least those that lead
+      to the current failure). Another, simpler approach would require
+      an application to show an error message with option to return
+      to a previous or home screen.</p>
 
     <p class="issue">Describe the various properties of an operation.</p>
   </section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -556,7 +556,7 @@
     <p>Keep in mind that operations specified in an <i>ApiDocumentation</i>
       may fail at runtime as either resources or the <i>ApiDocumentation</i>
       itself have changed since they have been retrieved. Also operation details
-      like <i>hydra:returns</i> or <i>hydra:statusCodes</i> may vary at runtime,
+      like <i>hydra:returns</i> or <i>hydra:possibleStatus</i> may vary at runtime,
       thus these interpreted at runtime. A simple strategy to try to recover from
       such a situation is to reload the <i>ApiDocumentation</i> and redo all
       operations that were based on the <i>ApiDocumentation</i> (or at least those
@@ -878,7 +878,7 @@
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@type": "****Status****",
-        ****"statusCode": 429****,
+        ****"possibleStatus": 429****,
         "title": "Too Many Requests",
         "description": "A maximum of 500 requests per hour and user is allowed.",
         ...


### PR DESCRIPTION
There was already a paragraph that mentioned a _volatile_ character of _ApiDocumentation_, which I've extended with direct references to _hydra:returns_ and _hydra:statusCodes_ hoping it will make the #32 resolved.