### PR TITLE
Add domainIncludes/rangeIncludes statements

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -113,6 +113,7 @@
       "label": "apiDocumentation",
       "comment": "A link to the API documentation",
       "range": "hydra:ApiDocumentation",
+      "domain": "hydra:Resource",
       "vs:term_status": "testing"
     },
     {
@@ -407,6 +408,7 @@
       "label": "search",
       "comment": "A IRI template that can be used to query a collection.",
       "range": "hydra:IriTemplate",
+      "domain": "hydra:Resource",
       "vs:term_status": "testing"
     },
     {
@@ -415,6 +417,7 @@
       "label": "freetext query",
       "comment": "A property representing a freetext query.",
       "range": "xsd:string",
+      "domain": "hydra:Resource",
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -8,6 +8,7 @@
     "vs": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
     "dc": "http://purl.org/dc/terms/",
     "cc": "http://creativecommons.org/ns#",
+    "schema": "http://schema.org/",
     "apiDocumentation": "hydra:apiDocumentation",
     "ApiDocumentation": "hydra:ApiDocumentation",
     "title": "hydra:title",
@@ -69,7 +70,8 @@
     "range": {"@id": "rdfs:range", "@type": "@vocab" },
     "subClassOf": { "@id": "rdfs:subClassOf", "@type": "@vocab" },
     "subPropertyOf": { "@id": "rdfs:subPropertyOf", "@type": "@vocab" },
-    "seeAlso": { "@id": "rdfs:seeAlso", "@type": "@id" }
+    "seeAlso": { "@id": "rdfs:seeAlso", "@type": "@id" },
+    "domainIncludes": { "@id": "schema:domainIncludes", "@type": "@id" }
   },
   "@id": "http://www.w3.org/ns/hydra/core",
   "@type": "owl:Ontology",
@@ -148,6 +150,7 @@
       "label": "possible status",
       "comment": "A status that might be returned by the Web API (other statuses should be expected and properly handled as well)",
       "range": "hydra:Status",
+      "domainIncludes": ["hydra:ApiDocumentation", "hydra:Operation"],
       "vs:term_status": "testing"
     },
     {
@@ -173,6 +176,7 @@
       "label": "property",
       "comment": "A property",
       "range": "rdf:Property",
+      "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
       "vs:term_status": "testing"
     },
     {
@@ -181,6 +185,7 @@
       "label": "required",
       "comment": "True if the property is required, false otherwise.",
       "range": "xsd:boolean",
+      "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
       "vs:term_status": "testing"
     },
     {
@@ -207,6 +212,7 @@
       "label": "supported operation",
       "comment": "An operation supported by instances of the specific Hydra class or the target of the Hydra link",
       "range": "hydra:Operation",
+      "domainIncludes": ["hydra:Class", "hydra:Link"],
       "vs:term_status": "testing"
     },
     {
@@ -277,6 +283,13 @@
       "label": "title",
       "comment": "A title, often used along with a description.",
       "range": "xsd:string",
+      "domainIncludes": [
+        "hydra:ApiDocumentation",
+        "hydra:Status",
+        "hydra:Class",
+        "hydra:SupportedProperty",
+        "hydra:Operation",
+        "hydra:Link"],
       "vs:term_status": "testing"
     },
     {
@@ -286,6 +299,13 @@
       "label": "description",
       "comment": "A description.",
       "range": "xsd:string",
+      "domainIncludes": [
+        "hydra:ApiDocumentation",
+        "hydra:Status",
+        "hydra:Class",
+        "hydra:SupportedProperty",
+        "hydra:Operation",
+        "hydra:Link"],
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -329,7 +329,8 @@
       "@type": "hydra:Link",
       "label": "collection",
       "comment": "Collections somehow related to this resource.",
-      "domain": "hydra:Collection",
+      "domain": "hydra:Resource",
+      "range": "hydra:Collection",
       "vs:term_status": "testing"
     },
     {
@@ -462,6 +463,8 @@
       "label": "template",
       "comment": "A templated string with placeholders. The literal's datatype indicates the template syntax; if not specified, hydra:Rfc6570Template is assumed.",
       "seeAlso": "hydra:Rfc6570Template",
+      "domain": "hydra:IriTemplate",
+      "range": "hydra:Rfc6570Template",
       "vs:term_status": "testing"
     },
     {
@@ -479,6 +482,7 @@
       "label": "variable representation",
       "comment": "The representation format to use when expanding the IRI template.",
       "range": "hydra:VariableRepresentation",
+      "domain": "hydra:IriTemplateMapping",
       "vs:term_status": "testing"
     },
     {


### PR DESCRIPTION
I've added some _domain_ predicates. There are other terms that would need this kind of specification, but they are applicable to more than type of resource. I hesitated to use both _schema:domainIncludes_ or _owl:unionOf_ based constructs. I didn't see any such a logic process that utilized _schem_ predicate and using _owl_ would bring mayhem to the spec.
Feel free to deliberate more.