### PR TITLE
add section about manages block

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -854,7 +854,7 @@
 
     <p>In the above example, adding a <code>manages</code> node to the collection instructs the
       client that every member of this collection is linked to the <code>subject</code>
-      by the <code>property</code>. It could be written a SPARQL triple pattern below, where
+      by the <code>property</code>. It could be written as a SPARQL triple pattern below, where
       <code>?m</code> would be substituted by each member of the collection.</p>
 
     <pre class="example nohighlight" data-transform="updateExample">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -868,7 +868,7 @@
       each expressing different relations between the collection members and other resources.</p>
 
     <p class="note">It's important to point out that the <code>subject</code>, <code>property</code>
-      and <code>object</code> predicate are defined within the Hydra namespace and are not
+      and <code>object</code> predicates are defined within the Hydra namespace and are not
       <a href="https://www.w3.org/TR/rdf-schema/"><code>rdf</code></a> terms.</p>
   </section>
 

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -748,7 +748,7 @@
     described somewhere in the beginning?</p>
 
   <section>
-    <h3>Collections</h3>
+    <h3 name="collections">Collections</h3>
 
     <p>In many situations, it makes sense to expose resources that reference
       a set of somehow related resources. Results of a search query or
@@ -821,6 +821,55 @@
 
     <p class="issue">Say that all these properties are optional? What about
       <i>first</i> and, perhaps more interestingly, <i>last</i>?</p>
+  </section>
+
+  <section>
+    <h4>"Manages block"</h4>
+
+    <p>A manages block is a way to declare additional, implicit statements about
+      members of a <a href="#collections">collection</a>. Statements which may otherwise
+      be missing from the respective member resources inlined in a collection's
+      representation.</p>
+
+    <pre class="example nohighlight"
+         data-transform="updateExample"
+         title="Manages block describes relation with another resource">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/an-issue/comments",
+        "@type": "Collection",
+        ****"manages": {
+          "subject": "http://api.example.com/an-issue",
+          "property": "http://api.example.com/vocab#comment"
+        }****,
+        "member": [
+          {
+            "@id": "/comments/429"
+          }
+        ]
+      }
+      -->
+    </pre>
+
+    <p>In the above example, adding a <code>manages</code> node to the collection instructs the
+      client that every member of this collection is linked to the <code>subject</code>
+      by the <code>property</code>. It could be written a SPARQL triple pattern below, where
+      <code>?m</code> would be substituted by each member of the collection.</p>
+
+    <pre class="example nohighlight" data-transform="updateExample">
+      <!--
+      <http://api.example.com/an-issue> <http://api.example.com/vocab#comment> ?m
+      -->
+    </pre>
+
+    <p>A manages block MUST use two and only two of the <code>subject</code>, <code>property</code>
+      and <code>object</code> predicates. There MAY be more than one such manages blocks,
+      each expressing different relations between the collection members and other resources.</p>
+
+    <p class="note">It's important to point out that the <code>subject</code>, <code>property</code>
+      and <code>object</code> predicate are defined within the Hydra namespace and are not
+      <a href="https://www.w3.org/TR/rdf-schema/"><code>rdf</code></a> terms.</p>
   </section>
 
   <section>
@@ -1006,7 +1055,7 @@
       Hydra defines just one such subclass, namely the <i>Error</i> class.
       This provides an extensible framework to communicate error details to
       a client.</p>
-    
+
     <p>Furthermore, a <i>Status</i> or <i>Error</i> returned by the server can also
       be given an identifier. When dereferenced, the <i>Error</i> resource can provide
       more detailed information or possible ways to resolve the problem, if applicable.<p/>


### PR DESCRIPTION
## Summary

I added the "manages" to the spec, finally 🎉 

## More details

We can close #41 which is directly related to this proposal and has already been "resolved".
For same reason we should close #126.

Fixes #194 as it aims to clarify the semantics and usage

I would like to close #150 and close #60 - the name "manages block" may should a little alien but I feel like it's a Hydra-specific enough construct to let it be justified. It's been around long enough too that it settled IMO.

## Related cookbook PR 

Previously partially addressed as #132