### PR TITLE
TemplatedLink cannot formally have supportedOperation

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -450,7 +450,7 @@
     {
       "@id": "hydra:TemplatedLink",
       "@type": "hydra:Class",
-      "subClassOf": [ "hydra:Resource", "rdf:Property" ],
+      "subClassOf": [ "hydra:Resource", "hydra:Link", "rdf:Property" ],
       "label": "Templated Link",
       "comment": "A templated link.",
       "vs:term_status": "testing"

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -218,7 +218,7 @@
       "label": "supported operation",
       "comment": "An operation supported by instances of the specific Hydra class or the target of the Hydra link",
       "range": "hydra:Operation",
-      "domainIncludes": ["hydra:Class", "hydra:Link"],
+      "domainIncludes": ["hydra:Class", "hydra:Link", "hydra:TemplatedLink"],
       "vs:term_status": "testing"
     },
     {
@@ -295,7 +295,8 @@
         "hydra:Class",
         "hydra:SupportedProperty",
         "hydra:Operation",
-        "hydra:Link"],
+        "hydra:Link",
+        "hydra:TemplatedLink"],
       "vs:term_status": "testing"
     },
     {
@@ -311,7 +312,8 @@
         "hydra:Class",
         "hydra:SupportedProperty",
         "hydra:Operation",
-        "hydra:Link"],
+        "hydra:Link",
+        "hydra:TemplatedLink"],
       "vs:term_status": "testing"
     },
     {
@@ -450,7 +452,7 @@
     {
       "@id": "hydra:TemplatedLink",
       "@type": "hydra:Class",
-      "subClassOf": [ "hydra:Resource", "hydra:Link", "rdf:Property" ],
+      "subClassOf": [ "hydra:Resource", "rdf:Property" ],
       "label": "Templated Link",
       "comment": "A templated link.",
       "vs:term_status": "testing"


### PR DESCRIPTION
## Summary

The `hydra:TemplatedLink` is not formally considered a `hydra:Link` so it cannot formally have any of the properties that are _allowed_ for `hydra:Link`. While in RDF each property can be used on every resource, it is still preferred to explicitly define some of the relations between terms so the client implementation is easier and the data model is stable.

## More details

The `hydra:TemplatedLink` is sub-classed from `hydra:Link` in this template making it formally also a `hydra:Link` which enables it to all properties define for `hydra:Link` with either `rdfs:domain` or `schema:domainIncludes`.