### PR TITLE
Enable hydra to expect and return non RDF resources

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -253,7 +253,8 @@
       "label": "expects",
       "comment": "The information expected by the Web API.",
       "domain": "hydra:Operation",
-      "range": "hydra:Class",
+      "range": "hydra:Resource",
+      "rangeIncludes": ["hydra:Resource", "hydra:Class"],
       "vs:term_status": "testing"
     },
     {
@@ -262,7 +263,8 @@
       "label": "returns",
       "comment": "The information returned by the Web API on success",
       "domain": "hydra:Operation",
-      "range": "hydra:Class",
+      "range": "hydra:Resource",
+      "rangeIncludes": ["hydra:Resource", "hydra:Class"],
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -77,7 +77,8 @@
     "subClassOf": { "@id": "rdfs:subClassOf", "@type": "@vocab" },
     "subPropertyOf": { "@id": "rdfs:subPropertyOf", "@type": "@vocab" },
     "seeAlso": { "@id": "rdfs:seeAlso", "@type": "@id" },
-    "domainIncludes": { "@id": "schema:domainIncludes", "@type": "@id" }
+    "domainIncludes": { "@id": "schema:domainIncludes", "@type": "@id" },
+    "rangeIncludes": { "@id": "schema:rangeIncludes", "@type": "@id" }
   },
   "@id": "http://www.w3.org/ns/hydra/core",
   "@type": "owl:Ontology",

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -533,7 +533,11 @@
       certain operations depend on the permissions of the current user. It
       makes it, e.g., possible to show a "delete" link only if the current
       user has the permission to delete the resource. Otherwise, the link
-      would simply be hidden in the representation.</p>
+      would simply be hidden in the representation.<br />
+      Example shown below describes the operation's expected and returned
+      value as a dereferencable resource (an RDF resource of a given class),
+      but the vocabulary is not limited to only those originating
+      from RDF and is enabled to other types of resources.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="Documenting the supported operations of link properties">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -533,8 +533,9 @@
       certain operations depend on the permissions of the current user. It
       makes it, e.g., possible to show a "delete" link only if the current
       user has the permission to delete the resource. Otherwise, the link
-      would simply be hidden in the representation.<br />
-      Example shown below describes the operation's expected and returned
+      would simply be hidden in the representation.</p>
+
+    <p>Example shown below describes the operation's expected and returned
       value as a dereferencable resource (an RDF resource of a given class),
       but the vocabulary is not limited to only those originating
       from RDF and is enabled to other types of resources.</p>


### PR DESCRIPTION
<!--
  Before proceeding, please read the Pull Request section in CONTRIBUTING.md (linked on the right)
-->

## Summary

I've changed the `rdfs:range` of `hydra:expects` and `hydra:returns` predicates from `hydra:Class` to `hydra:Resource` and introduced `schema:rangeIncludes` for both.
I've also mentioned that fact in the spec.

## More details

This PR addresses issues #22 and #199 but does *NOT* resolves them. It is also an alternative approach to PRs #186 and #187.

Sole purpose is to enable the vocabulary to expect and return non-RDF resources. Previous specification placed a `hydra:Class` in the range the proper predicates making it difficult to use other types of resources.
Unfortunately, modification within the `rdfs:range` of the aforementioned predicates may introduce possible issues within current implementations and specifications built on top of the vocabulary. Still, it seems to be the least intrusive method due to facts:
- the `hydra:Class` used previously is still compliant with newly introduced `hydra:Resource`
- `schema:rangeIncludes` introduced does not apply strict RDF type entailing rules yet still provides semantic hints on possible values.