### PR TITLE
Allowed supportedOperation on SupportedProperty.

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -98,7 +98,7 @@
       "subClassOf": "rdfs:Resource",
       "label": "Hydra Resource",
       "comment": "The class of dereferenceable resources.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Class",
@@ -106,7 +106,7 @@
       "subClassOf": [ "hydra:Resource", "rdfs:Class" ],
       "label": "Hydra Class",
       "comment": "The class of Hydra classes. Hydra classes and their instances are dereferenceable resources.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Link",
@@ -114,7 +114,7 @@
       "subClassOf": [ "hydra:Resource", "rdf:Property" ],
       "label": "Link",
       "comment": "The class of properties representing links.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:apiDocumentation",
@@ -123,7 +123,7 @@
       "comment": "A link to the API documentation",
       "range": "hydra:ApiDocumentation",
       "domain": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:ApiDocumentation",
@@ -131,7 +131,7 @@
       "subClassOf": "hydra:Resource",
       "label": "ApiDocumentation",
       "comment": "The Hydra API documentation class",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:entrypoint",
@@ -140,7 +140,7 @@
       "comment": "A link to main entry point of the Web API",
       "domain": "hydra:ApiDocumentation",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:supportedClass",
@@ -149,7 +149,7 @@
       "comment": "A class known to be supported by the Web API",
       "domain": "hydra:ApiDocumentation",
       "range": "hydra:Class",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:possibleStatus",
@@ -184,7 +184,7 @@
       "comment": "A property",
       "range": "rdf:Property",
       "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:required",
@@ -193,8 +193,8 @@
       "comment": "True if the property is required, false otherwise.",
       "range": "xsd:boolean",
       "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
-      "vs:term_status": "stable"
-    },
+      "vs:term_status": "testing"
+`    },
     {
       "@id": "hydra:readable",
       "@type": "rdf:Property",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -194,7 +194,7 @@
       "range": "xsd:boolean",
       "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
       "vs:term_status": "testing"
-`    },
+    },
     {
       "@id": "hydra:readable",
       "@type": "rdf:Property",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -98,7 +98,7 @@
       "subClassOf": "rdfs:Resource",
       "label": "Hydra Resource",
       "comment": "The class of dereferenceable resources.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:Class",
@@ -106,7 +106,7 @@
       "subClassOf": [ "hydra:Resource", "rdfs:Class" ],
       "label": "Hydra Class",
       "comment": "The class of Hydra classes. Hydra classes and their instances are dereferenceable resources.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:Link",
@@ -114,7 +114,7 @@
       "subClassOf": [ "hydra:Resource", "rdf:Property" ],
       "label": "Link",
       "comment": "The class of properties representing links.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:apiDocumentation",
@@ -123,7 +123,7 @@
       "comment": "A link to the API documentation",
       "range": "hydra:ApiDocumentation",
       "domain": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:ApiDocumentation",
@@ -131,7 +131,7 @@
       "subClassOf": "hydra:Resource",
       "label": "ApiDocumentation",
       "comment": "The Hydra API documentation class",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:entrypoint",
@@ -140,7 +140,7 @@
       "comment": "A link to main entry point of the Web API",
       "domain": "hydra:ApiDocumentation",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:supportedClass",
@@ -149,7 +149,7 @@
       "comment": "A class known to be supported by the Web API",
       "domain": "hydra:ApiDocumentation",
       "range": "hydra:Class",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:possibleStatus",
@@ -184,7 +184,7 @@
       "comment": "A property",
       "range": "rdf:Property",
       "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:required",
@@ -193,7 +193,7 @@
       "comment": "True if the property is required, false otherwise.",
       "range": "xsd:boolean",
       "domainIncludes": ["hydra:SupportedProperty", "hydra:IriTemplateMapping"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:readable",
@@ -202,7 +202,7 @@
       "comment": "True if the client can retrieve the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:writeable",
@@ -211,7 +211,7 @@
       "comment": "True if the client can change the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:supportedOperation",
@@ -219,7 +219,7 @@
       "label": "supported operation",
       "comment": "An operation supported by instances of the specific Hydra class or the target of the Hydra link",
       "range": "hydra:Operation",
-      "domainIncludes": ["hydra:Class", "hydra:Link", "hydra:TemplatedLink"],
+      "domainIncludes": ["hydra:Class", "hydra:Link", "hydra:TemplatedLink", "hydra:SupportedProperty"],
       "vs:term_status": "testing"
     },
     {
@@ -246,7 +246,7 @@
       "comment": "The HTTP method.",
       "domain": "hydra:Operation",
       "range": "xsd:string",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:expects",
@@ -256,7 +256,7 @@
       "domain": "hydra:Operation",
       "range": "hydra:Resource",
       "rangeIncludes": ["hydra:Resource", "hydra:Class"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:returns",
@@ -266,7 +266,7 @@
       "domain": "hydra:Operation",
       "range": "hydra:Resource",
       "rangeIncludes": ["hydra:Resource", "hydra:Class"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:Status",
@@ -300,7 +300,7 @@
         "hydra:Operation",
         "hydra:Link",
         "hydra:TemplatedLink"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:description",
@@ -317,7 +317,7 @@
         "hydra:Operation",
         "hydra:Link",
         "hydra:TemplatedLink"],
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:Error",
@@ -333,7 +333,7 @@
       "subClassOf": "hydra:Resource",
       "label": "Collection",
       "comment": "A collection holding references to a number of related resources.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:collection",
@@ -342,26 +342,26 @@
       "comment": "Collections somehow related to this resource.",
       "domain": "hydra:Resource",
       "range": "hydra:Collection",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:manages",
       "label": "manages",
       "comment": "Semantics of each member provided by the collection.",
       "domain": "hydra:Collection",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:subject",
       "label": "subject",
       "comment": "The subject.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:object",
       "label": "object",
       "comment": "The object.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:member",
@@ -370,7 +370,7 @@
       "comment": "A member of the collection",
       "domain": "hydra:Collection",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:view",
@@ -379,7 +379,7 @@
       "comment": "A specific view of a resource.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:PartialCollectionView",
@@ -387,7 +387,7 @@
       "subClassOf": "hydra:Resource",
       "label": "PartialCollectionView",
       "comment": "A PartialCollectionView describes a partial view of a Collection. Multiple PartialCollectionViews can be connected with the the next/previous properties to allow a client to retrieve all members of the collection.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:totalItems",
@@ -396,7 +396,7 @@
       "comment": "The total number of items referenced by a collection.",
       "domain": "hydra:Collection",
       "range": "xsd:integer",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:first",
@@ -405,7 +405,7 @@
       "comment": "The first resource of an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:last",
@@ -414,7 +414,7 @@
       "comment": "The last resource of an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:next",
@@ -423,7 +423,7 @@
       "comment": "The resource following the current instance in an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:previous",
@@ -432,7 +432,7 @@
       "comment": "The resource preceding the current instance in an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:search",
@@ -441,7 +441,7 @@
       "comment": "A IRI template that can be used to query a collection.",
       "range": "hydra:IriTemplate",
       "domain": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:freetextQuery",
@@ -450,7 +450,7 @@
       "comment": "A property representing a freetext query.",
       "range": "xsd:string",
       "domain": "hydra:Resource",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:TemplatedLink",
@@ -458,7 +458,7 @@
       "subClassOf": [ "hydra:Resource", "rdf:Property" ],
       "label": "Templated Link",
       "comment": "A templated link.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:IriTemplate",
@@ -466,7 +466,7 @@
       "subClassOf": "hydra:Resource",
       "label": "IRI Template",
       "comment": "The class of IRI templates.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:template",
@@ -476,7 +476,7 @@
       "seeAlso": "hydra:Rfc6570Template",
       "domain": "hydra:IriTemplate",
       "range": "hydra:Rfc6570Template",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:Rfc6570Template",
@@ -485,7 +485,7 @@
       "comment": "An IRI template as defined by RFC6570.",
       "seeAlso": "http://tools.ietf.org/html/rfc6570",
       "range": "xsd:string",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:variableRepresentation",
@@ -494,7 +494,7 @@
       "comment": "The representation format to use when expanding the IRI template.",
       "range": "hydra:VariableRepresentation",
       "domain": "hydra:IriTemplateMapping",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:VariableRepresentation",
@@ -502,21 +502,21 @@
       "subClassOf": "hydra:Resource",
       "label": "VariableRepresentation",
       "comment": "A representation specifies how to serialize variable values into strings.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:BasicRepresentation",
       "@type": "hydra:VariableRepresentation",
       "label": "BasicRepresentation",
       "comment": "A representation that serializes just the lexical form of a variable value, but omits language and type information.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:ExplicitRepresentation",
       "@type": "hydra:VariableRepresentation",
       "label": "ExplicitRepresentation",
       "comment": "A representation that serializes a variable value including its language and type information and thus differentiating between IRIs and literals.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:mapping",
@@ -525,7 +525,7 @@
       "comment": "A variable-to-property mapping of the IRI template.",
       "domain": "hydra:IriTemplate",
       "range": "hydra:IriTemplateMapping",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:IriTemplateMapping",
@@ -533,7 +533,7 @@
       "subClassOf": "hydra:Resource",
       "label": "IriTemplateMapping",
       "comment": "A mapping from an IRI template variable to a property.",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:variable",
@@ -542,7 +542,7 @@
       "comment": "An IRI template variable",
       "domain": "hydra:IriTemplateMapping",
       "range": "xsd:string",
-      "vs:term_status": "testing"
+      "vs:term_status": "stable"
     },
     {
       "@id": "hydra:offset",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -202,7 +202,7 @@
       "comment": "True if the client can retrieve the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:writeable",
@@ -211,7 +211,7 @@
       "comment": "True if the client can change the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:supportedOperation",
@@ -246,7 +246,7 @@
       "comment": "The HTTP method.",
       "domain": "hydra:Operation",
       "range": "xsd:string",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:expects",
@@ -256,7 +256,7 @@
       "domain": "hydra:Operation",
       "range": "hydra:Resource",
       "rangeIncludes": ["hydra:Resource", "hydra:Class"],
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:returns",
@@ -266,7 +266,7 @@
       "domain": "hydra:Operation",
       "range": "hydra:Resource",
       "rangeIncludes": ["hydra:Resource", "hydra:Class"],
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Status",
@@ -300,7 +300,7 @@
         "hydra:Operation",
         "hydra:Link",
         "hydra:TemplatedLink"],
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:description",
@@ -317,7 +317,7 @@
         "hydra:Operation",
         "hydra:Link",
         "hydra:TemplatedLink"],
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Error",
@@ -333,7 +333,7 @@
       "subClassOf": "hydra:Resource",
       "label": "Collection",
       "comment": "A collection holding references to a number of related resources.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:collection",
@@ -342,26 +342,26 @@
       "comment": "Collections somehow related to this resource.",
       "domain": "hydra:Resource",
       "range": "hydra:Collection",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:manages",
       "label": "manages",
       "comment": "Semantics of each member provided by the collection.",
       "domain": "hydra:Collection",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:subject",
       "label": "subject",
       "comment": "The subject.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:object",
       "label": "object",
       "comment": "The object.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:member",
@@ -370,7 +370,7 @@
       "comment": "A member of the collection",
       "domain": "hydra:Collection",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:view",
@@ -379,7 +379,7 @@
       "comment": "A specific view of a resource.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:PartialCollectionView",
@@ -387,7 +387,7 @@
       "subClassOf": "hydra:Resource",
       "label": "PartialCollectionView",
       "comment": "A PartialCollectionView describes a partial view of a Collection. Multiple PartialCollectionViews can be connected with the the next/previous properties to allow a client to retrieve all members of the collection.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:totalItems",
@@ -396,7 +396,7 @@
       "comment": "The total number of items referenced by a collection.",
       "domain": "hydra:Collection",
       "range": "xsd:integer",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:first",
@@ -405,7 +405,7 @@
       "comment": "The first resource of an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:last",
@@ -414,7 +414,7 @@
       "comment": "The last resource of an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:next",
@@ -423,7 +423,7 @@
       "comment": "The resource following the current instance in an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:previous",
@@ -432,7 +432,7 @@
       "comment": "The resource preceding the current instance in an interlinked set of resources.",
       "domain": "hydra:Resource",
       "range": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:search",
@@ -441,7 +441,7 @@
       "comment": "A IRI template that can be used to query a collection.",
       "range": "hydra:IriTemplate",
       "domain": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:freetextQuery",
@@ -450,7 +450,7 @@
       "comment": "A property representing a freetext query.",
       "range": "xsd:string",
       "domain": "hydra:Resource",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:TemplatedLink",
@@ -458,7 +458,7 @@
       "subClassOf": [ "hydra:Resource", "rdf:Property" ],
       "label": "Templated Link",
       "comment": "A templated link.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:IriTemplate",
@@ -466,7 +466,7 @@
       "subClassOf": "hydra:Resource",
       "label": "IRI Template",
       "comment": "The class of IRI templates.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:template",
@@ -476,7 +476,7 @@
       "seeAlso": "hydra:Rfc6570Template",
       "domain": "hydra:IriTemplate",
       "range": "hydra:Rfc6570Template",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Rfc6570Template",
@@ -485,7 +485,7 @@
       "comment": "An IRI template as defined by RFC6570.",
       "seeAlso": "http://tools.ietf.org/html/rfc6570",
       "range": "xsd:string",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:variableRepresentation",
@@ -494,7 +494,7 @@
       "comment": "The representation format to use when expanding the IRI template.",
       "range": "hydra:VariableRepresentation",
       "domain": "hydra:IriTemplateMapping",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:VariableRepresentation",
@@ -502,21 +502,21 @@
       "subClassOf": "hydra:Resource",
       "label": "VariableRepresentation",
       "comment": "A representation specifies how to serialize variable values into strings.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:BasicRepresentation",
       "@type": "hydra:VariableRepresentation",
       "label": "BasicRepresentation",
       "comment": "A representation that serializes just the lexical form of a variable value, but omits language and type information.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:ExplicitRepresentation",
       "@type": "hydra:VariableRepresentation",
       "label": "ExplicitRepresentation",
       "comment": "A representation that serializes a variable value including its language and type information and thus differentiating between IRIs and literals.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:mapping",
@@ -525,7 +525,7 @@
       "comment": "A variable-to-property mapping of the IRI template.",
       "domain": "hydra:IriTemplate",
       "range": "hydra:IriTemplateMapping",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:IriTemplateMapping",
@@ -533,7 +533,7 @@
       "subClassOf": "hydra:Resource",
       "label": "IriTemplateMapping",
       "comment": "A mapping from an IRI template variable to a property.",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:variable",
@@ -542,7 +542,7 @@
       "comment": "An IRI template variable",
       "domain": "hydra:IriTemplateMapping",
       "range": "xsd:string",
-      "vs:term_status": "stable"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:offset",

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -601,6 +601,14 @@
       for the operation invocation.
     </pre>
 
+    <p>To wrap up everything altogether, it is also possible to attach atomic
+      operations supported by, well, supported property itself. This might
+      come in handy for scenarios, when resource can be partially modified.
+      It can be achieved by adding a <i>supportedOperation</i> to the
+      intermediate structure mentioned earlier, <i>SupportedProperty</i>.
+      This way prevents from leaking API specific features from the API itself
+      to i.e. externally defined properties.</p>
+
     <p>These are the simple example scenarios and possible usages are not
       limited to those described above.</p>
 

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -604,10 +604,24 @@
     <p>To wrap up everything altogether, it is also possible to attach atomic
       operations supported by, well, supported property itself. This might
       come in handy for scenarios, when resource can be partially modified.
-      It can be achieved by adding a <i>supportedOperation</i> to the
-      intermediate structure mentioned earlier, <i>SupportedProperty</i>.
+      It can be achieved with two approaches, both having advantages and
+      disadvantages.</p>
+
+    <p>First approach would involve adding a <i>supportedOperation</i> to the
+      intermediate structure of <i>SupportedProperty</i>.
       This way prevents from leaking API specific features from the API itself
-      to i.e. externally defined properties.</p>
+      to i.e. externally defined properties. Data aggregators won't assume that
+      each instance with a given property could have such an operation.</p>
+
+    <p>Another approach would require the API to elevate a specific property
+      to <i>Link</i>, which can accept a <i>supportedOperation</i>. This
+      is more intuitive in APIs operating with internally used vocabularies
+      where assumption that every instance with that very specific property
+      has the operation attached available.</p>
+
+    <p>Direct usage of <i>supportedOperation</i> on <i>rdf:Property</i>
+      without elevating it to the <i>Link</i> SHOULD NOT be implemented as clients
+      may not discover such a construct correctly.</p>
 
     <p>These are the simple example scenarios and possible usages are not
       limited to those described above.</p>


### PR DESCRIPTION
## Summary

Allowing _supportedOperation_ predicate on _SupportedProperty_ instances.
It also marks several terms as *stable*.

## More details

This PR fixes issue #196. In general, there were doubts on how to (if possible) attach a supported operation to the property. There were few examples that did this by using _supportedOperation_ on the property itself, but this was incorrect neither from the raw range/domain point of view defined within the RDF spec nor semantic understanding of such approach.

This PR enables _supportedOperation_ to be formally attachable to instances of _SupportedProperty_. This way this intermediate structure can hold any API specific details preventing from leaking it to externally defined properties.

