### PR TITLE
Relative Template URIs

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -545,6 +545,36 @@
       "vs:term_status": "testing"
     },
     {
+      "@id": "hydra:resolveRelativeTo",
+      "@type": "rdf:Property",
+      "label": "relative Uri resolution",
+      "domain": "hydra:IriTemplate",
+      "range": "hydra:BaseUriSource",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:BaseUriSource",
+      "@type": "hydra:Class",
+      "subClassOf": "hydra:Resource",
+      "label": "Base Uri source",
+      "comment": "Provides a base abstract for base Uri source for Iri template resolution.",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:Rfc3986Based",
+      "@type": "hydra:BaseUriSource",
+      "label": "RFC 3986 based",
+      "comment": "States that the base Uri should be established using RFC 3986 algorithm.",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:LinkContext",
+      "@type": "hydra:BaseUriSource",
+      "label": "Link context",
+      "comment": "States that the base Uri should be established via a link context.",
+      "vs:term_status": "testing"
+    },
+    {
       "@id": "hydra:offset",
       "@type": "rdf:Property",
       "label": "skip",

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1040,24 +1040,22 @@
       -->
     </pre>
 
-    <p>Iri expansion should be performed with respect to the specification
-      behind the iri template type (which is RFC 6570 by default), and the
-      product of this process SHOULD be an Iri. In may happen that this
-      product is a relative Uri. In such a case client by default SHOULD
-      stick to RFC 3986. It is due to fact that most RDF serialization
-      allowing other that absolute Iris will behave that way and the result
-      of Iri template expansion should be compliant. Still, it may be
-      preferred to use other base Uri for the expansion process, which
+    <p>IRI expansion should be performed with respect to the specification
+      behind the IRI template type (RFC 6570 by default), and the product
+      of this process SHOULD be an IRI. When the produced IRI is relative,
+      a case client SHOULD stick to RFC 3986 sections 5.1.3 and 5.1.4 to be compatible
+      with most RDF serializations that support relative IRIs. Still, it may be
+      preferred to use another base URI for the expansion process, which
       makes a <i>resolveRelativeTo</i> term useful. It allows to switch the
-      Iri template expansion algorithm so the base Uri is established using
-      current link context, which is a subject of the relation pointing to
-      <i>IriTemplate</i> instance. In case that subject is a relative Uri,
+      IRI template expansion algorithm so the base URI is established using
+      current link context, which is a subject of the relation pointing to an
+      <i>IriTemplate</i> instance. In case that subject is a relative URI,
       default behavior SHOULD be used as fallback.</p>
 
-    <p>The example below allows to hook the product of an Iri template
-      expansion to the <i>http://api.example.com/an-issue/</i> resource
-      as it's base Uri, which further enables the <i>some:operation</i> to
-      be moved to i.e. Api documentation level rather to inline it.</p>
+    <p>The example below allows to make the product of an IRI template
+      expansion relative to the <i>http://api.example.com/an-issue/</i> resource
+      by using it as its base URI, which further enables the <i>some:operation</i> to
+      be moved to i.e. API documentation level rather to inline it.</p>
 
     <pre class="example nohighlight"
          data-transform="updateExample"

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1039,6 +1039,44 @@
       }
       -->
     </pre>
+
+    <p>Iri expansion should be performed with respect to the specification
+      behind the iri template type (which is RFC 6570 by default), and the
+      product of this process SHOULD be an Iri. In may happen that this
+      product is a relative Uri. In such a case client by default SHOULD
+      stick to RFC 3986. It is due to fact that most RDF serialization
+      allowing other that absolute Iris will behave that way and the result
+      of Iri template expansion should be compliant. Still, it may be
+      preferred to use other base Uri for the expansion process, which
+      makes a <i>resolveRelativeTo</i> term useful. It allows to switch the
+      Iri template expansion algorithm so the base Uri is established using
+      current link context, which is a subject of the relation pointing to
+      <i>IriTemplate</i> instance. In case that subject is a relative Uri,
+      default behavior SHOULD be used as fallback.</p>
+
+    <p>The example below allows to hook the product of an Iri template
+      expansion to the <i>http://api.example.com/an-issue/</i> resource
+      as it's base Uri, which further enables the <i>some:operation</i> to
+      be moved to i.e. Api documentation level rather to inline it.</p>
+
+    <pre class="example nohighlight"
+         data-transform="updateExample"
+         title="Custom base Uri resolution for an Iri template">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/an-issue/",
+        "@type": "Collection",
+        "some:operation": {
+          "@type": "IriTemplate",
+          "template": "/{id}",
+          "resolveRelativeTo": "LinkContext",
+          "variable": "id",
+          "mapping": {...}
+        }
+      }
+      -->
+    </pre>
   </section>
 
   <section>


### PR DESCRIPTION
## Summary
Added few more terms to enable different base Uri resolution mechanism of Iri template expansion products which should address issue #208:

- resolveRelativeTo
- BaseUriSource
- Rfc3986Based
- LinkContext

## More details

During a discussion on issue #208 an interesting concept of Iri templates provided on the API documentation level was introduced. While very interesting and tempting, there was no clean way of providing relative Iri templates that could be resolved properly against inlined resources. 
This pull request addresses this issue by introducing some terms that could change the default client behavior while resolving relative Uri that are products or Iri template expansion.