### PR TITLE
How to document forbidden dereferencability

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -97,15 +97,15 @@
       "@type": "hydra:Class",
       "subClassOf": "rdfs:Resource",
       "label": "Hydra Resource",
-      "comment": "The class of dereferenceable resources.",
+      "comment": "The class of dereferenceable resources by means a client can at least try to obtain a resource but it still should verify received payloads.",
       "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Class",
       "@type": [ "hydra:Resource", "rdfs:Class" ],
-      "subClassOf": [ "hydra:Resource", "rdfs:Class" ],
+      "subClassOf": [ "rdfs:Class" ],
       "label": "Hydra Class",
-      "comment": "The class of Hydra classes. Hydra classes and their instances are dereferenceable resources.",
+      "comment": "The class of Hydra classes.",
       "vs:term_status": "testing"
     },
     {
@@ -148,7 +148,7 @@
       "label": "supported classes",
       "comment": "A class known to be supported by the Web API",
       "domain": "hydra:ApiDocumentation",
-      "range": "hydra:Class",
+      "range": "rdfs:Class",
       "vs:term_status": "testing"
     },
     {
@@ -165,14 +165,14 @@
       "@type": "hydra:Link",
       "label": "supported properties",
       "comment": "The properties known to be supported by a Hydra class",
-      "domain": "hydra:Class",
+      "domain": "rdfs:Class",
       "range": "hydra:SupportedProperty",
       "vs:term_status": "testing"
     },
     {
       "@id": "hydra:SupportedProperty",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "Supported Property",
       "comment": "A property known to be supported by a Hydra class.",
       "vs:term_status": "testing"
@@ -219,7 +219,7 @@
       "label": "supported operation",
       "comment": "An operation supported by instances of the specific Hydra class or the target of the Hydra link",
       "range": "hydra:Operation",
-      "domainIncludes": ["hydra:Class", "hydra:Link", "hydra:TemplatedLink", "hydra:SupportedProperty"],
+      "domainIncludes": ["rdfs:Class", "hydra:Class", "hydra:Link", "hydra:TemplatedLink", "hydra:SupportedProperty"],
       "vs:term_status": "testing"
     },
     {
@@ -234,7 +234,7 @@
     {
       "@id": "hydra:Operation",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "Operation",
       "comment": "An operation.",
       "vs:term_status": "testing"
@@ -254,8 +254,8 @@
       "label": "expects",
       "comment": "The information expected by the Web API.",
       "domain": "hydra:Operation",
-      "range": "hydra:Resource",
-      "rangeIncludes": ["hydra:Resource", "hydra:Class"],
+      "range": "rdfs:Resource",
+      "rangeIncludes": ["rdfs:Resource", "hydra:Resource", "rdfs:Class", "hydra:Class"],
       "vs:term_status": "testing"
     },
     {
@@ -264,14 +264,14 @@
       "label": "returns",
       "comment": "The information returned by the Web API on success",
       "domain": "hydra:Operation",
-      "range": "hydra:Resource",
-      "rangeIncludes": ["hydra:Resource", "hydra:Class"],
+      "range": "rdfs:Resource",
+      "rangeIncludes": ["rdfs:Resource", "hydra:Resource", "rdfs:Class", "hydra:Class"],
       "vs:term_status": "testing"
     },
     {
       "@id": "hydra:Status",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "Status code description",
       "comment": "Additional information about a status code that might be returned.",
       "vs:term_status": "testing"
@@ -340,7 +340,7 @@
       "@type": "hydra:Link",
       "label": "collection",
       "comment": "Collections somehow related to this resource.",
-      "domain": "hydra:Resource",
+      "domain": "rdfs:Resource",
       "range": "hydra:Collection",
       "vs:term_status": "testing"
     },
@@ -369,7 +369,7 @@
       "label": "member",
       "comment": "A member of the collection",
       "domain": "hydra:Collection",
-      "range": "hydra:Resource",
+      "range": "rdfs:Resource",
       "vs:term_status": "testing"
     },
     {
@@ -377,8 +377,8 @@
       "@type": "hydra:Link",
       "label": "view",
       "comment": "A specific view of a resource.",
-      "domain": "hydra:Resource",
-      "range": "hydra:Resource",
+      "domain": "rdfs:Resource",
+      "range": "rdfs:Resource",
       "vs:term_status": "testing"
     },
     {
@@ -463,7 +463,7 @@
     {
       "@id": "hydra:IriTemplate",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "IRI Template",
       "comment": "The class of IRI templates.",
       "vs:term_status": "testing"
@@ -499,7 +499,7 @@
     {
       "@id": "hydra:VariableRepresentation",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "VariableRepresentation",
       "comment": "A representation specifies how to serialize variable values into strings.",
       "vs:term_status": "testing"
@@ -530,7 +530,7 @@
     {
       "@id": "hydra:IriTemplateMapping",
       "@type": "hydra:Class",
-      "subClassOf": "hydra:Resource",
+      "subClassOf": "rdfs:Resource",
       "label": "IriTemplateMapping",
       "comment": "A mapping from an IRI template variable to a property.",
       "vs:term_status": "testing"

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -251,7 +251,6 @@
       "label": "expects",
       "comment": "The information expected by the Web API.",
       "domain": "hydra:Operation",
-      "range": "rdfs:Resource",
       "rangeIncludes": ["rdfs:Resource", "hydra:Resource", "rdfs:Class", "hydra:Class"],
       "vs:term_status": "testing"
     },
@@ -261,7 +260,6 @@
       "label": "returns",
       "comment": "The information returned by the Web API on success",
       "domain": "hydra:Operation",
-      "range": "rdfs:Resource",
       "rangeIncludes": ["rdfs:Resource", "hydra:Resource", "rdfs:Class", "hydra:Class"],
       "vs:term_status": "testing"
     },
@@ -364,7 +362,6 @@
       "label": "member",
       "comment": "A member of the collection",
       "domain": "hydra:Collection",
-      "range": "rdfs:Resource",
       "vs:term_status": "testing"
     },
     {
@@ -372,8 +369,6 @@
       "@type": "hydra:Link",
       "label": "view",
       "comment": "A specific view of a resource.",
-      "domain": "rdfs:Resource",
-      "range": "rdfs:Resource",
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -95,9 +95,8 @@
     {
       "@id": "hydra:Resource",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "Hydra Resource",
-      "comment": "The class of dereferenceable resources by means a client can at least try to obtain a resource but it still should verify received payloads.",
+      "comment": "The class of dereferenceable resources by means a client can attempt to dereference; however, the received responses should still be verified.",
       "vs:term_status": "testing"
     },
     {
@@ -172,7 +171,6 @@
     {
       "@id": "hydra:SupportedProperty",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "Supported Property",
       "comment": "A property known to be supported by a Hydra class.",
       "vs:term_status": "testing"
@@ -234,7 +232,6 @@
     {
       "@id": "hydra:Operation",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "Operation",
       "comment": "An operation.",
       "vs:term_status": "testing"
@@ -271,7 +268,6 @@
     {
       "@id": "hydra:Status",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "Status code description",
       "comment": "Additional information about a status code that might be returned.",
       "vs:term_status": "testing"
@@ -340,7 +336,6 @@
       "@type": "hydra:Link",
       "label": "collection",
       "comment": "Collections somehow related to this resource.",
-      "domain": "rdfs:Resource",
       "range": "hydra:Collection",
       "vs:term_status": "testing"
     },
@@ -463,7 +458,6 @@
     {
       "@id": "hydra:IriTemplate",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "IRI Template",
       "comment": "The class of IRI templates.",
       "vs:term_status": "testing"
@@ -499,7 +493,6 @@
     {
       "@id": "hydra:VariableRepresentation",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "VariableRepresentation",
       "comment": "A representation specifies how to serialize variable values into strings.",
       "vs:term_status": "testing"
@@ -530,7 +523,6 @@
     {
       "@id": "hydra:IriTemplateMapping",
       "@type": "hydra:Class",
-      "subClassOf": "rdfs:Resource",
       "label": "IriTemplateMapping",
       "comment": "A mapping from an IRI template variable to a property.",
       "vs:term_status": "testing"


### PR DESCRIPTION
## Summary

Please find the modifications (removal of `hydra:Resource`) of the several `rdfs:range`, `rdfs:domain` and `rdfs:subClassOf` definitions that should fix imposed resource dereferencability .

## More details

This should address issue #216 as the core issue was that several places in hydra imposed fact that resources are dereferencable, which in many cases was untrue (not to mention the fact that having i.e. an HTTP based URL doesn't mean it can be freely dereferenced).

There are still a few places where `hydra:Resource` is left:
- both `hydra:Link` and `hydra:TemplatedLink` are still `hydra:Resource`. Removing it from `hydra:Link` could break hydra:apiDocumentation as it actually should be dereferencable. Also links defined by API should connect callable resources.
- the `hydra:operation` has still domain of `hydra:Resource`. Operations should be invokable on a callable resource.
- both `hydra:Collection` and `hydra:PartialCollectionView` are still sub-classes of `hydra:Resource`. These are API artificial wrappers over some resource sets and should be callable.
- all hydra links like `hydra:first`/`hydra:last`/`hydra:next`/`hydra:prev` have still `hydra:Resource` as both their domains and ranges. Otherwise the described _interlinked set of resources_ would cease to be, well, interlinked.
- both `hydra:search` and `hydra:freetextQuery` have still `hydra:Resource` as it's domain. If a client came that far to have that link, it probably means that the resource is already callable.

Feel free to participate in the review as this is a major modification that should improve hydra's applicability to other than RDF areas.