### PR TITLE
#178 Make hydra:error compatible with RFC 7807

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -31,6 +31,7 @@
     "Status": "hydra:Status",
     "statusCode": "hydra:statusCode",
     "Error": "hydra:Error",
+    "errorCode": "hydra:errorCode",
     "Resource": "hydra:Resource",
     "operation": "hydra:operation",
     "Collection": "hydra:Collection",
@@ -319,6 +320,15 @@
       "subClassOf": "hydra:Status",
       "label": "Error",
       "comment": "A runtime error, used to report information beyond the returned status code.",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:errorCode",
+      "@type": "rdf:Property",
+      "subPropertyOf": "hydra:statusCode",
+      "label": "error code",
+      "comment": "The HTTP status code that is considered an error",
+      "domain": "hydra:Error",
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -15,7 +15,7 @@
     "description": "hydra:description",
     "entrypoint": { "@id": "hydra:entrypoint", "@type": "@id" },
     "supportedClass": { "@id": "hydra:supportedClass", "@type": "@vocab" },
-    "Class": "hydra:Class",
+    "Class": "hydra:Class","@id": "hydra:Status",
     "supportedProperty": { "@id": "hydra:supportedProperty", "@type": "@id" },
     "SupportedProperty": "hydra:SupportedProperty",
     "property": { "@id": "hydra:property", "@type": "@vocab" },
@@ -283,10 +283,10 @@
       "@id": "hydra:statusCode",
       "@type": "rdf:Property",
       "label": "status code",
-      "comment": "The HTTP status code. It is not recommended to provide this predicate in direct responses.",
+      "comment": "The HTTP status code. It is fully optional and it may happen to be different to actual status code received.",
       "domain": "hydra:Status",
       "range": "xsd:integer",
-      "vs:term_status": "archaic"
+      "vs:term_status": "testing"
     },
     {
       "@id": "hydra:title",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -32,7 +32,6 @@
     "Status": "hydra:Status",
     "statusCode": "hydra:statusCode",
     "Error": "hydra:Error",
-    "errorCode": "hydra:errorCode",
     "Resource": "hydra:Resource",
     "operation": "hydra:operation",
     "Collection": "hydra:Collection",
@@ -284,10 +283,10 @@
       "@id": "hydra:statusCode",
       "@type": "rdf:Property",
       "label": "status code",
-      "comment": "The HTTP status code",
+      "comment": "The HTTP status code. It is not recommended to provide this predicate in direct responses.",
       "domain": "hydra:Status",
       "range": "xsd:integer",
-      "vs:term_status": "testing"
+      "vs:term_status": "archaic"
     },
     {
       "@id": "hydra:title",
@@ -329,15 +328,6 @@
       "subClassOf": "hydra:Status",
       "label": "Error",
       "comment": "A runtime error, used to report information beyond the returned status code.",
-      "vs:term_status": "testing"
-    },
-    {
-      "@id": "hydra:errorCode",
-      "@type": "rdf:Property",
-      "subPropertyOf": "hydra:statusCode",
-      "label": "error code",
-      "comment": "The HTTP status code that is considered an error",
-      "domain": "hydra:Error",
       "vs:term_status": "testing"
     },
     {

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -15,7 +15,7 @@
     "description": "hydra:description",
     "entrypoint": { "@id": "hydra:entrypoint", "@type": "@id" },
     "supportedClass": { "@id": "hydra:supportedClass", "@type": "@vocab" },
-    "Class": "hydra:Class","@id": "hydra:Status",
+    "Class": "hydra:Class",
     "supportedProperty": { "@id": "hydra:supportedProperty", "@type": "@id" },
     "SupportedProperty": "hydra:SupportedProperty",
     "property": { "@id": "hydra:property", "@type": "@vocab" },
@@ -283,7 +283,7 @@
       "@id": "hydra:statusCode",
       "@type": "rdf:Property",
       "label": "status code",
-      "comment": "The HTTP status code. It is fully optional and it may happen to be different to actual status code received.",
+      "comment": "The HTTP status code. Please note it may happen this value will be different to actual status code received.",
       "domain": "hydra:Status",
       "range": "xsd:integer",
       "vs:term_status": "testing"

--- a/spec/latest/core/error.jsonld
+++ b/spec/latest/core/error.jsonld
@@ -1,9 +1,11 @@
 {
   "@context": {
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "hydra": "http://www.w3.org/ns/hydra/core#",
     "type": "@type",
     "title": "rdfs:label",
     "detail": "rdfs:comment",
+    "status": "hydra:statusCode",
     "instance": { "@id": "rdfs:seeAlso", "@type": "@id" }
   }
 }

--- a/spec/latest/core/error.jsonld
+++ b/spec/latest/core/error.jsonld
@@ -1,11 +1,9 @@
 {
   "@context": {
-    "hydra": "http://www.w3.org/ns/hydra/core#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "type": "@type",
-    "title": "hydra:title",
-    "detail": "hydra:description",
-    "status": "hydra:errorCode",
+    "title": "rdfs:label",
+    "detail": "rdfs:comment",
     "instance": { "@id": "rdfs:seeAlso", "@type": "@id" }
   }
 }

--- a/spec/latest/core/error.jsonld
+++ b/spec/latest/core/error.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "hydra": "http://www.w3.org/ns/hydra/core#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "type": "@type",
+    "title": "hydra:title",
+    "detail": "hydra:description",
+    "status": "hydra:errorCode",
+    "instance": { "@id": "rdfs:seeAlso", "@type": "@id" }
+  }
+}

--- a/spec/latest/core/error.jsonld
+++ b/spec/latest/core/error.jsonld
@@ -1,8 +1,9 @@
 {
   "@context": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "hydra": "http://www.w3.org/ns/hydra/core#",
-    "type": "@type",
+    "type": { "@id": "rdf:type", "@type": "@id" },
     "title": "rdfs:label",
     "detail": "rdfs:comment",
     "status": "hydra:statusCode",

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1266,6 +1266,35 @@
       }
       -->
     </pre>
+
+    <p>It is also possible to provide an [[!RFC7807]] compatible</a> error description.
+      To do so, server should provide a <i>application/problem+json</i> response with additional header
+      pointing to <i>http://www.w3.org/ns/hydra/error.context.jsonld</i> context.</p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="RFC-7807 compatible error description">
+      <!--
+      HTTP/1.1 400 Bad Request
+      Content-Type: application/problem+json
+      Link: <http://www.w3.org/ns/hydra/error.context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"
+
+      {
+        "type": "https://example.com/probs/out-of-credit",
+        "title": "You do not have enough credit.",
+        "detail": "Your current balance is 30, but that costs 50.",
+        "instance": "/account/12345/msgs/abc",
+        "balance": 30,
+        "accounts": ["/account/12345",
+                     "/account/67890"]
+      }
+      -->
+    </pre>
+
+    <p>While this approach makes the response fully compatible with the mentioned specification,
+      properties not defined in the standard Hydra's error context won't be visible for Hydra aware processor.
+      To overcome this, it is possible to declare own context pointed same way, that would combine standard
+      Hydra's error context and a <i>JSON-LD</i>'s with either the <i>@vocab</i> or custom property mappings
+      telling the processor on how to interpret those custom error properties.</p>
   </section>
 
   <section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1284,7 +1284,7 @@
 
     <p>Resources provided may have an additional hint pointing to an <i>Error</i> type like in the example
       above, but it is not mandatory to do so as all resources described with <i>application/problem+json</i>
-      are considered errors.</p>
+      are considered <i>hydra:Error</i>.</p>
 
     <p>It is worth to mention that it may happen (i.e. due to proxy behavior) the value of the <i>status</i> property
       will differ to the one received from the protocol layer.</p>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1250,11 +1250,11 @@
       be given an identifier. When dereferenced, the <i>Error</i> resource can provide
       more detailed information or possible ways to resolve the problem, if applicable.<p/>
 
-    <p>Finally, server SHOULD provide error descriptions using an [[!RFC7807]] standard.
-      by using a <i>application/problem+json</i> response. When doing so server also MUST provide
-      an additional header pointing to either built-in Hydra <i>http://www.w3.org/ns/hydra/error</i>
-      context or any JSON-LD context that maps terms <i>type</i>, <i>title</i>, <i>detail</i>
-      and <i>instance</i> same way as the standard one.</p>
+    <p>Finally, the server SHOULD provide error descriptions using an [[!RFC7807]] standard
+      by using an <i>application/problem+json</i> response. When doing so, the server also MUST provide
+      an additional header pointing to either the built-in Hydra <i>http://www.w3.org/ns/hydra/error</i>
+      context or any JSON-LD context that maps the terms <i>type</i>, <i>title</i>, <i>detail</i>
+      and <i>instance</i> the same way as the standard one.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="RFC-7807 compatible error description">
@@ -1277,8 +1277,8 @@
     </pre>
 
     <p>While the built-in context makes the response fully compatible with the mentioned specification,
-      properties not defined in the standard Hydra's error context won't be visible for Hydra aware processor.
-      To overcome this, it is possible to declare an own context pointed the same way, that would combine standard
+      properties not defined in the standard Hydra's error context won't be visible for Hydra aware processors.
+      To overcome this, it is possible to declare a custom context pointed the same way, that would combine standard
       Hydra's error context and an additional JSON-LD context with either the <i>@vocab</i> or custom property mappings
       telling the processor on how to interpret those custom error properties.</p>
 
@@ -1286,9 +1286,9 @@
       above, but it is not mandatory to do so as all resources described with <i>application/problem+json</i>
       are considered errors.</p>
 
-    <p>It is worth to mention that the <i>http://www.w3.org/ns/hydra/error</i> context does not map
-      the <i>status</i> property. It is due to possible discrepancies that may occur between actual status returned
-      and the status provided within the payload.</p>
+    <p>It is worth to mention that the <i>status</i> property is optional and while it should be the same as the
+      actual status received with the response, it may happen (i.e. due to proxy behavior) it will differ to the one
+      received from the protocol layer.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="Non RFC-7807 compliant error description using raw Hydra JSON-LD representation.">

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1250,8 +1250,48 @@
       be given an identifier. When dereferenced, the <i>Error</i> resource can provide
       more detailed information or possible ways to resolve the problem, if applicable.<p/>
 
+    <p>Finally, server SHOULD provide error descriptions using an [[!RFC7807]] standard.
+      by using a <i>application/problem+json</i> response. When doing so server also MUST provide
+      an additional header pointing to either built-in Hydra <i>http://www.w3.org/ns/hydra/error</i>
+      context or any JSON-LD context that maps terms <i>type</i>, <i>title</i>, <i>detail</i>
+      and <i>instance</i> same way as the standard one.</p>
+
     <pre class="example nohighlight" data-transform="updateExample"
-         title="Using Hydra's Error class to describe errors">
+         title="RFC-7807 compatible error description">
+      <!--
+      HTTP/1.1 400 Bad Request
+      Content-Type: application/problem+json
+      Link: <http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#context"
+
+      {
+        "type": "https://example.com/probs/out-of-credit",
+        "@type": "http://www.w3.org/ns/hydra/core#Error",
+        "title": "You do not have enough credit.",
+        "detail": "Your current balance is 30, but that costs 50.",
+        "instance": "/account/12345/msgs/abc",
+        "balance": 30,
+        "accounts": ["/account/12345",
+                     "/account/67890"]
+      }
+      -->
+    </pre>
+
+    <p>While the built-in context makes the response fully compatible with the mentioned specification,
+      properties not defined in the standard Hydra's error context won't be visible for Hydra aware processor.
+      To overcome this, it is possible to declare an own context pointed the same way, that would combine standard
+      Hydra's error context and an additional JSON-LD context with either the <i>@vocab</i> or custom property mappings
+      telling the processor on how to interpret those custom error properties.</p>
+
+    <p>Resources provided may have an additional hint pointing to an <i>Error</i> type like in the example
+      above, but it is not mandatory to do so as all resources described with <i>application/problem+json</i>
+      are considered errors.</p>
+
+    <p>It is worth to mention that the <i>http://www.w3.org/ns/hydra/error</i> context does not map
+      the <i>status</i> property. It is due to possible discrepancies that may occur between actual status returned
+      and the status provided within the payload.</p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Non RFC-7807 compliant error description using raw Hydra JSON-LD representation.">
       <!--
       HTTP/1.1 400 Bad Request
       Content-Type: application/ld+json
@@ -1266,35 +1306,6 @@
       }
       -->
     </pre>
-
-    <p>It is also possible to provide an [[!RFC7807]] compatible</a> error description.
-      To do so, server can provide a <i>application/problem+json</i> response. Server also
-      MUST provide an additional header pointing to <i>http://www.w3.org/ns/hydra/error</i> context.</p>
-
-    <pre class="example nohighlight" data-transform="updateExample"
-         title="RFC-7807 compatible error description">
-      <!--
-      HTTP/1.1 400 Bad Request
-      Content-Type: application/problem+json
-      Link: <http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#context"
-
-      {
-        "type": "https://example.com/probs/out-of-credit",
-        "title": "You do not have enough credit.",
-        "detail": "Your current balance is 30, but that costs 50.",
-        "instance": "/account/12345/msgs/abc",
-        "balance": 30,
-        "accounts": ["/account/12345",
-                     "/account/67890"]
-      }
-      -->
-    </pre>
-
-    <p>While this approach makes the response fully compatible with the mentioned specification,
-      properties not defined in the standard Hydra's error context won't be visible for Hydra aware processor.
-      To overcome this, it is possible to declare own context pointed the same way, that would combine standard
-      Hydra's error context and an additional JSON-LD context with either the <i>@vocab</i> or custom property mappings
-      telling the processor on how to interpret those custom error properties.</p>
   </section>
 
   <section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1268,15 +1268,15 @@
     </pre>
 
     <p>It is also possible to provide an [[!RFC7807]] compatible</a> error description.
-      To do so, server should provide a <i>application/problem+json</i> response with additional header
-      pointing to <i>http://www.w3.org/ns/hydra/error.context.jsonld</i> context.</p>
+      To do so, server can provide a <i>application/problem+json</i> response. Server also
+      MUST provide an additional header pointing to <i>http://www.w3.org/ns/hydra/error</i> context.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="RFC-7807 compatible error description">
       <!--
       HTTP/1.1 400 Bad Request
       Content-Type: application/problem+json
-      Link: <http://www.w3.org/ns/hydra/error.context.jsonld>; rel="http://www.w3.org/ns/json-ld#context"
+      Link: <http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#context"
 
       {
         "type": "https://example.com/probs/out-of-credit",
@@ -1292,8 +1292,8 @@
 
     <p>While this approach makes the response fully compatible with the mentioned specification,
       properties not defined in the standard Hydra's error context won't be visible for Hydra aware processor.
-      To overcome this, it is possible to declare own context pointed same way, that would combine standard
-      Hydra's error context and a <i>JSON-LD</i>'s with either the <i>@vocab</i> or custom property mappings
+      To overcome this, it is possible to declare own context pointed the same way, that would combine standard
+      Hydra's error context and an additional JSON-LD context with either the <i>@vocab</i> or custom property mappings
       telling the processor on how to interpret those custom error properties.</p>
   </section>
 

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1253,8 +1253,8 @@
     <p>Finally, the server SHOULD provide error descriptions using an [[!RFC7807]] standard
       by using an <i>application/problem+json</i> response. When doing so, the server also MUST provide
       an additional header pointing to either the built-in Hydra <i>http://www.w3.org/ns/hydra/error</i>
-      context or any JSON-LD context that maps the terms <i>type</i>, <i>title</i>, <i>detail</i>
-      and <i>instance</i> the same way as the standard one.</p>
+      context or any JSON-LD context that maps the terms <i>type</i>, <i>title</i>, <i>detail</i>,
+      <i>status</i> and <i>instance</i> the same way as the standard one.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="RFC-7807 compatible error description">
@@ -1279,16 +1279,15 @@
     <p>While the built-in context makes the response fully compatible with the mentioned specification,
       properties not defined in the standard Hydra's error context won't be visible for Hydra aware processors.
       To overcome this, it is possible to declare a custom context pointed the same way, that would combine standard
-      Hydra's error context and an additional JSON-LD context with either the <i>@vocab</i> or custom property mappings
-      telling the processor on how to interpret those custom error properties.</p>
+      Hydra's standard error context and an additional JSON-LD context with either the <i>@vocab</i>
+      or custom property mappings telling the processor on how to interpret those custom error properties.</p>
 
     <p>Resources provided may have an additional hint pointing to an <i>Error</i> type like in the example
       above, but it is not mandatory to do so as all resources described with <i>application/problem+json</i>
       are considered errors.</p>
 
-    <p>It is worth to mention that the <i>status</i> property is optional and while it should be the same as the
-      actual status received with the response, it may happen (i.e. due to proxy behavior) it will differ to the one
-      received from the protocol layer.</p>
+    <p>It is worth to mention that it may happen (i.e. due to proxy behavior) the value of the <i>status</i> property
+      will differ to the one received from the protocol layer.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="Non RFC-7807 compliant error description using raw Hydra JSON-LD representation.">


### PR DESCRIPTION
## Summary

Changes are covering new standard JSON-LD context that maps RFC-7807 specific JSON properties to Hydra vocabulary.

## More details

This pull-request should resolve issue #718 by introducing two new things:
- standard JSON-LD context that maps RFC-7807 JSON properties to Hydra core vocabulary
- `errorCode` term that is required to make that output of that standard JSON-LD context a `hydra:Error` resource

It may still valid to drop the second change - the only drawback would be the resulting resource would've been a `hydra:Status` which makes the `hydra:Error` itself somehow obsolete (which is not that bad after all).