### PR TITLE
#150 #211 Renamed manages to memberAssertion and writeable to writable

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -21,6 +21,7 @@
     "property": { "@id": "hydra:property", "@type": "@vocab" },
     "required": "hydra:required",
     "readable": "hydra:readable",
+    "writable": "hydra:writable",
     "writeable": "hydra:writeable",
     "supportedOperation": { "@id": "hydra:supportedOperation", "@type": "@id" },
     "Operation": "hydra:Operation",
@@ -36,6 +37,7 @@
     "Collection": "hydra:Collection",
     "collection": "hydra:collection",
     "member": { "@id": "hydra:member", "@type": "@id" },
+    "memberAssertion": "hydra:memberAssertion",
     "manages": "hydra:manages",
     "subject": { "@id": "hydra:subject", "@type": "@vocab" },
     "object": { "@id": "hydra:object", "@type": "@vocab" },
@@ -203,13 +205,20 @@
       "vs:term_status": "testing"
     },
     {
-      "@id": "hydra:writeable",
+      "@id": "hydra:writable",
       "@type": "rdf:Property",
-      "label": "writeable",
+      "label": "writable",
       "comment": "True if the client can change the property's value, false otherwise.",
       "domain": "hydra:SupportedProperty",
       "range": "xsd:boolean",
       "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:writeable",
+      "subPropertyOf": "hydra:writable",
+      "label": "writable",
+      "comment": "This property is left for compatibility purposes and hydra:writable should be used instead.",
+      "vs:term_status": "archaic"
     },
     {
       "@id": "hydra:supportedOperation",
@@ -338,11 +347,18 @@
       "vs:term_status": "testing"
     },
     {
-      "@id": "hydra:manages",
+      "@id": "hydra:memberAssertion",
       "label": "manages",
       "comment": "Semantics of each member provided by the collection.",
       "domain": "hydra:Collection",
       "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:manages",
+      "subPropertyOf": "hydra:memberAssertion",
+      "label": "manages",
+      "comment": "This predicate is left for compatibility purposes and hydra:memberAssertion should be used instead.",
+      "vs:term_status": "archaic"
     },
     {
       "@id": "hydra:subject",

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -348,7 +348,7 @@
     },
     {
       "@id": "hydra:memberAssertion",
-      "label": "manages",
+      "label": "member assertion",
       "comment": "Semantics of each member provided by the collection.",
       "domain": "hydra:Collection",
       "vs:term_status": "testing"

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -497,7 +497,7 @@
             ****"property"****: "#property", ####// The property####
             ****"required"****: true, ####// Is the property required in a request to be valid?####
             ****"readable"****: false, ####// Can the client retrieve the property's value?####
-            ****"writeable"****: true ####// Can the client change the property's value?####
+            ****"writable"****: true ####// Can the client change the property's value?####
           }
         ]
       }
@@ -907,7 +907,7 @@
   <section>
     <h4>"Manages block"</h4>
 
-    <p>A manages block is a way to declare additional, implicit statements about
+    <p>A <i>memberAssertion</i> block is a way to declare additional, implicit statements about
       members of a <a href="#collections">collection</a>. Statements which may otherwise
       be missing from the respective member resources inlined in a collection's
       representation.</p>
@@ -920,7 +920,7 @@
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@id": "http://api.example.com/an-issue/comments",
         "@type": "Collection",
-        ****"manages": {
+        ****"memberAssertion": {
           "subject": "http://api.example.com/an-issue",
           "property": "http://api.example.com/vocab#comment"
         }****,
@@ -933,7 +933,7 @@
       -->
     </pre>
 
-    <p>In the above example, adding a <code>manages</code> node to the collection instructs the
+    <p>In the above example, adding a <code>memberAssertion</code> node to the collection instructs the
       client that every member of this collection is linked to the <code>subject</code>
       by the <code>property</code>. It could be written as a SPARQL triple pattern below, where
       <code>?m</code> would be substituted by each member of the collection.</p>
@@ -944,8 +944,8 @@
       -->
     </pre>
 
-    <p>A manages block MUST use two and only two of the <code>subject</code>, <code>property</code>
-      and <code>object</code> predicates. There MAY be more than one such manages blocks,
+    <p>A <i>memberAssertion</i> block MUST use two and only two of the <code>subject</code>, <code>property</code>
+      and <code>object</code> predicates. There MAY be more than one such blocks,
       each expressing different relations between the collection members and other resources.</p>
 
     <p class="note">It's important to point out that the <code>subject</code>, <code>property</code>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -905,9 +905,9 @@
   </section>
 
   <section>
-    <h4>"Manages block"</h4>
+    <h4>Member assertions</h4>
 
-    <p>A <i>memberAssertion</i> block is a way to declare additional, implicit statements about
+    <p>A <i>memberAssertion</i> is a way to declare additional, implicit statements about
       members of a <a href="#collections">collection</a>. Statements which may otherwise
       be missing from the respective member resources inlined in a collection's
       representation.</p>
@@ -944,9 +944,9 @@
       -->
     </pre>
 
-    <p>A <i>memberAssertion</i> block MUST use two and only two of the <code>subject</code>, <code>property</code>
-      and <code>object</code> predicates. There MAY be more than one such blocks,
-      each expressing different relations between the collection members and other resources.</p>
+    <p>A <i>memberAssertion</i> MUST use two and only two of the <code>subject</code>, <code>property</code>
+      and <code>object</code> predicates. There <code>memberAssertion</code> predicate MAY have more than one
+      such blocks, each expressing different relations between the collection members and other resources.</p>
 
     <p class="note">It's important to point out that the <code>subject</code>, <code>property</code>
       and <code>object</code> predicates are defined within the Hydra namespace and are not


### PR DESCRIPTION
## Summary

This is a technical pull request that renames `manages` to `memberAssertion` which should resolve issue #150 and `writeable` to `writable` which should resolve issue #211.

## More details

For compatibility purposes old terms are left as being sub-properties of their replacements and are marked as `archaic` (obsolete)
