### PR TITLE
Changed totalItems literals to numbers rather than string values

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -847,7 +847,7 @@
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@id": "http://api.example.com/an-issue/comments",
         ****"@type": "Collection"****,
-        ****"totalItems": "4980"****,
+        ****"totalItems": 4980****,
         ****"member"****: [
           {
             "@id": "/comments/429"
@@ -884,7 +884,7 @@
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@id": "http://api.example.com/an-issue/comments",
         "@type": "Collection",
-        "totalItems": "4980",
+        "totalItems": 4980,
         "member": [
           ####... a subset of the members of the Collection ...####
         ],


### PR DESCRIPTION
## Summary

This pull request replaces string literals for `hydra:totalItems` predicate in the examples with numeric ones.

## More details

Changes should resolve the #205 issue. Numeric literals for the `hydra:totalItems` feels more readable and intuitive rather than string ones.