### PR TITLE
Way for API to announce any extensions they use in addition to Hydra Core

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -634,6 +634,7 @@
       "label": "extension",
       "comment": "Hint on what kind of extensions are in use.",
       "domain": "hydra:ApiDocumentation",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
       "vs:term_status": "testing"
     }
   ]

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -68,6 +68,7 @@
     "pageReference": { "@id": "hydra:pageReference" },
     "returnsHeader": { "@id": "hydra:returnsHeader", "@type": "xsd:string" },
     "expectsHeader": { "@id": "hydra:expectsHeader", "@type": "xsd:string" },
+    "extension": { "@id": "hydra:extension", "@type": "@id" },
     "defines": { "@reverse": "rdfs:isDefinedBy" },
     "comment": "rdfs:comment",
     "label": "rdfs:label",
@@ -625,6 +626,13 @@
       "comment": "Specification of the header expected by the operation.",
       "domain": "hydra:Operation",
       "range": "xsd:string",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:extension",
+      "@type": "rdf:Property",
+      "label": "extension",
+      "comment": "Hint on what kind of extensions are in use.",
       "vs:term_status": "testing"
     }
   ]

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -633,6 +633,7 @@
       "@type": "rdf:Property",
       "label": "extension",
       "comment": "Hint on what kind of extensions are in use.",
+      "domain": "hydra:ApiDocumentation",
       "vs:term_status": "testing"
     }
   ]

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1294,11 +1294,11 @@
       not every aspect of API behavior can be covered with it. This
       applies especially to querying, resource projection or data structure
       description. This is due to fact that Hydra was meant to be as light
-      as possible forcing to drop some of the features out of it; scope.</p>
+      as possible forcing to drop some of the features out of its scope.</p>
 
     <p>That is why there is a possibility of hinting a client on what kind
       of extensions may be found or used in the received payloads.
-      After discovering a <i>extension</i> predicate wherever in the payload,
+      After discovering a <i>extension</i> predicate in the API documentation,
       client can assume additional details are available described with
       additional vocabularies.</p>
 
@@ -1309,14 +1309,28 @@
 
     <p>Server SHOULD NOT use extensions to add statements that are in
       contradiction to base Hydra interpretation so the client is not confused.
-      Server also SHOULD keep multiple extensions describing adequate
+      Server SHOULD also keep multiple extensions describing adequate
       knowledge in line regarding their description (i.e. data structure
       descriptions in various vocabularies should not cause differences).</p>
 
-    <p>Client can express it's preferences through the <i>PREFER</i> header
-      by pointing the preferred extensions via IRIs. Server SHOULD implement
-      that header according to [[!RFC7240]] and implementers should proceed
-      with caution.</p>
+    <p>Client can express its preferences through the <i>PREFER</i> header
+      by pointing the preferred extensions via IRIs as on the example below.
+      The expectation of <i>hydra.extension</i> should be followed by a
+      semicolon which then should be followed by an <i>iri</i> parameter
+      expressed as an extension's IRI enclosed within a double quotes.
+      Multiple preferences can be expressed by providing multiple
+      <i>PREFER</i> header values.</p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Hydra client extension preference.">
+      <!--
+      GET http://api.example.com/api/people
+      Prefer: hydra.extension; iri="http://schema.org/"
+      -->
+    </pre>
+
+    <p>Server SHOULD implement <i>PREFER</i> header handling according to
+      the [[!RFC7240]] and implementers should proceed with caution.</p>
   </section>
 </section>
 

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1290,20 +1290,20 @@
 
   <section>
     <h3>Extensions</h3>
-    <p>While Hydra Core Vocabulary allows to address many usage scenarios,
-      not every aspect of API behavior can be covered with it. This
+    <p>While Hydra Core Vocabulary allows addressing many usage scenarios,
+      not every aspect of API behavior can be covered. This
       applies especially to querying, resource projection or data structure
-      description. This is due to fact that Hydra was meant to be as light
+      description. This is due to fact that Hydra is meant to be as light
       as possible forcing to drop some of the features out of its scope.</p>
 
     <p>That is why there is a possibility of hinting a client on what kind
       of extensions may be found or used in the received payloads.
-      After discovering a <i>extension</i> predicate in the API documentation,
+      After discovering an <i>extension</i> predicate in the API documentation,
       client can assume additional details are available described with
-      additional vocabularies.</p>
+      complementary vocabularies.</p>
 
-    <p>It is up to the used vocabulary how these additional details should be
-      interpreted and in case client does not recognize these extensions,
+    <p>It is up to the used vocabulary to define how these additional details should be
+      interpreted. In case client does not recognize these extensions,
       additional details should be ignored and base Hydra interpretation
       should be in force.</p>
 
@@ -1313,13 +1313,13 @@
       knowledge in line regarding their description (i.e. data structure
       descriptions in various vocabularies should not cause differences).</p>
 
-    <p>Client can express its preferences through the <i>PREFER</i> header
+    <p>Client can express its preferences through the <i>Prefer</i> HTTP header
       by pointing the preferred extensions via IRIs as on the example below.
-      The expectation of <i>hydra.extension</i> should be followed by a
-      semicolon which then should be followed by an <i>iri</i> parameter
-      expressed as an extension's IRI enclosed within a double quotes.
-      Multiple preferences can be expressed by providing multiple
-      <i>PREFER</i> header values.</p>
+      The client SHOULD use the <i>Prefer</i> HTTP header [[!RFC7240]] with
+      the <i>hydra.extension</i> preference as an <i>iri</i> attribute having
+      the IRI of the extension as value to hint the server about the extension
+      it supports. Multiple preferences can be expressed by providing multiple
+      <i>Prefer</i> header values.</p>
 
     <pre class="example nohighlight" data-transform="updateExample"
          title="Hydra client extension preference.">
@@ -1329,7 +1329,7 @@
       -->
     </pre>
 
-    <p>Server SHOULD implement <i>PREFER</i> header handling according to
+    <p>Server MUST implement <i>Prefer</i> header handling according to
       the [[!RFC7240]] and implementers should proceed with caution.</p>
   </section>
 </section>

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1302,6 +1302,22 @@
       client can assume additional details are available described with
       complementary vocabularies.</p>
 
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Hydra client extension usage.">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/doc/",
+        "@type": "ApiDocumentation",
+        "title": "The name of the API",
+        "description": "A short description of the API",
+        "entrypoint": "URL of the API's main entry point",
+        ****"extension": "http://www.w3.org/ns/shacl#"****,
+        ...
+      }
+      -->
+    </pre>
+
     <p>It is up to the used vocabulary to define how these additional details should be
       interpreted. In case client does not recognize these extensions,
       additional details should be ignored and base Hydra interpretation
@@ -1325,7 +1341,7 @@
          title="Hydra client extension preference.">
       <!--
       GET http://api.example.com/api/people
-      Prefer: hydra.extension; iri="http://schema.org/"
+      ****Prefer: hydra.extension; iri="http://schema.org/"****
       -->
     </pre>
 

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1287,6 +1287,37 @@
       to provide a custom page identifier (i.e. a GUID or a letter)
       instead of a number.</p>
   </section>
+
+  <section>
+    <h3>Extensions</h3>
+    <p>While Hydra Core Vocabulary allows to address many usage scenarios,
+      not every aspect of API behavior can be covered with it. This
+      applies especially to querying, resource projection or data structure
+      description. This is due to fact that Hydra was meant to be as light
+      as possible forcing to drop some of the features out of it; scope.</p>
+
+    <p>That is why there is a possibility of hinting a client on what kind
+      of extensions may be found or used in the received payloads.
+      After discovering a <i>extension</i> predicate wherever in the payload,
+      client can assume additional details are available described with
+      additional vocabularies.</p>
+
+    <p>It is up to the used vocabulary how these additional details should be
+      interpreted and in case client does not recognize these extensions,
+      additional details should be ignored and base Hydra interpretation
+      should be in force.</p>
+
+    <p>Server SHOULD NOT use extensions to add statements that are in
+      contradiction to base Hydra interpretation so the client is not confused.
+      Server also SHOULD keep multiple extensions describing adequate
+      knowledge in line regarding their description (i.e. data structure
+      descriptions in various vocabularies should not cause differences).</p>
+
+    <p>Client can express it's preferences through the <i>PREFER</i> header
+      by pointing the preferred extensions via IRIs. Server SHOULD implement
+      that header according to [[!RFC7240]] and implementers should proceed
+      with caution.</p>
+  </section>
 </section>
 
 <!-- <section>


### PR DESCRIPTION
Introduction of the `hydra:extension` predicate that should resolve issue #221

## Summary

This PR should resolve issue #221 by introducing a new term by which server could announce extensions in use. Additionally, client can express it's preferences regarding those extensions.

## More details

While in the issue there was a suggestion of using a `hydra:profile` term, I decided to use `hydra:extension`. The word `profile` introduced was meant to reflect how descriptive logic of OWL changes with different OWL profiles, thus it didn't feel like a correct word to use. Finally, _extension_ feels more generic and does not imply any specific behavior other than _something additional to the base Hydra description_ that client may or may not understand.