### PR TITLE
Addressed issues #13, #21 and #61

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -402,6 +402,88 @@
       context is the same for a lot of representations in a Web API and
       it thus makes sense to reduce the response size by leveraging a
       remote context that can easily be cached by a client.</p>
+
+    <p>It is worth to mention that due to fact that hydra is on top of
+      an RDF, which is a graph, it may happen that a related resource
+      (an object of the relation) may not be fully described in the
+      resource's payload. In several circumstances (i.e. payload terms
+      defined in <i>API documentation</i> sa described in
+      <a href="#documenting-a-web-api">Documenting a Web API</a>
+      or <i>IriTemplate</i> expected as a related resource as described in
+      <a href="#templated-links">Templated Links</a>) client may
+      discover no additional statements describing it. These rules should
+      be considered by the client in those scenarios:
+    </p>
+
+    <ul>
+      <li>in case of an object expected to be a hypermedia resource does not have all
+        the necessary statements for which it is a subject, client SHOULD look in the
+        <i>API documentation</i> for more details</li>
+      <li>in case the mentioned object, after consulting an <i>API documentation</i>, still
+        does not have all the necessary statements for which it is a subject and both
+        mentioned object's Url and Url of the initially obtained resource has the
+        same scheme and authority (by means of [[!RFC3986]] sections 3.1 and 3.2), client
+        SHOULD de-reference that Url. If the resource does not have the same scheme and
+        authority the client MAY choose to de-reference it (for example if the resource
+        originates from another API well-known to the client)</li>
+      <li>in case the mentioned object, still does not have all the necessary
+        statements for which it is a subject (i.e. de-referencing it failed
+        or statements are missing), client SHOULD either ignore whole
+        statement (i.e. for display purposes) or throw an exception (i.e. an
+        <i>IriTemplate</i> is about to be resolved and de-referenced)</li>
+    </ul>
+
+    <p>Example of each of the situations are as follows:</p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="IriTemplate details extraction">
+      <!--
+      HTTP/1.1 200 OK
+      Content-Type: application/ld+json
+      Link: <http://api.example.com/doc/>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"
+
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@graph": [{
+          "@id": "http://api.example.com/people",
+          "@type": "hydra:Collection",
+          "api:personByName": "api:PersonByNameTemplate"
+        }, {
+          "@id": "http://api.example.com/events",
+          "@type": "hydra:Collection",
+          "api:eventByName": "api:EventByNameTemplate"
+        }
+      }
+
+      HTTP/1.1 200 OK
+      Content-Type: application/ld+json
+
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@graph": [{
+          "@id": "api:PersonByNameTemplate",
+          "@type": "hydra:IriTemplate",
+          "template": "http://api.example.com/people/{name}",
+          ...
+        }]
+      }
+      -->
+    </pre>
+
+    <p>where</p>
+
+    <ul>
+      <li>resource <i>http://api.example.com/people</i> should have an <i>IriTemplate</i> available
+        as there is a complete definition of the template available at <i>http://api.example.com/doc/</i>.</li>
+      <li>resource <i>http://api.example.com/events</i> should not have an Iri template exposed as there
+        are no additional details available, neither in the initial resources' payload nor in the API documentation.</li>
+    </ul>
+
+    <p>Keep in mind that any resource described by any hypermedia control
+      may fail at runtime due to various reasons. Also operation details
+      like <i>returns</i> or <i>possibleStatus</i> may vary at runtime,
+      which means client SHOULD always verify received payloads at runtime.
+      </p>
   </section>
 
   <section>
@@ -626,12 +708,9 @@
     <p>These are the simple example scenarios and possible usages are not
       limited to those described above.</p>
 
-    <p>Keep in mind that operations specified in an <i>ApiDocumentation</i>
-      may fail at runtime as either resources or the <i>ApiDocumentation</i>
-      itself have changed since they have been retrieved. Also operation details
-      like <i>returns</i> or <i>possibleStatus</i> may vary at runtime,
-      which means client SHOULD verify received payloads at runtime.
-      A simple strategy to try to recover from such a situation is to reload
+    <p>Due to fact an <i>ApiDocumentation</i> as all other resources may fail
+      at runtime, it is important to take countermeasures.
+      A simple strategy to try to recover from such a situation would be to reload
       the <i>ApiDocumentation</i> and redo all pre-computations that were
       based on the <i>ApiDocumentation</i> (or at least those that lead
       to the current failure). Another, simpler approach would require
@@ -1093,79 +1172,6 @@
       }
       -->
     </pre>
-
-    <p>Due to fact that hydra is on top of an RDF, which is a graph,
-      it may happen that a related resource (an object of the relation)
-      may not be fully described in the resource's payload. In case of
-      an <i>IriTemplate</i> expected as a related resource, client may
-      discover no additional statements describing it. These rules should
-      be considered when working with <i>IriTemplate</i>s (and other
-      hypermedia resources in general):
-    </p>
-
-    <ul>
-      <li>in case of an object expected to be a hypermedia resource does not have all
-        the necessary statements for which it is a subject, client SHOULD look in the
-        API documentation for more details</li>
-      <li>in case the mentioned object, after consulting an API documentation, still
-        does not have all the necessary statements for which it is a subject and both
-        mentioned object's Url and Url of the initially obtained resource has the
-        same scheme and authority (by means of RFC 3986 sections 3.1 and 3.2), client
-        SHOULD dereference that Url. If the resource does not have the same scheme and
-        authority the client MAY choose to derefernce it (for example if the resource
-        originates from another API well-known to the client)</li>
-      <li>in case the mentioned object, still does not have all the necessary
-        statements for which it is a subject (i.e. de-referencing it failed
-        or statements are missing), client SHOULD either ignore whole
-        statement (i.e. for display purposes) or throw an exception (i.e. an
-        Iri template is about to be resolved and de-referenced)</li>
-    </ul>
-
-    <p>Example of each of the situations are as follows:</p>
-
-    <pre class="example nohighlight" data-transform="updateExample"
-         title="IriTemplate details extraction">
-      <!--
-      HTTP/1.1 200 OK
-      Content-Type: application/ld+json
-      Link: <http://api.example.com/doc/>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"
-
-      {
-        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-        "@graph": [{
-          "@id": "http://api.example.com/people",
-          "@type": "hydra:Collection",
-          "api:personByName": "api:PersonByNameTemplate"
-        }, {
-          "@id": "http://api.example.com/events",
-          "@type": "hydra:Collection",
-          "api:eventByName": "api:EventByNameTemplate"
-        }
-      }
-
-      HTTP/1.1 200 OK
-      Content-Type: application/ld+json
-
-      {
-        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-        "@graph": [{
-          "@id": "api:PersonByNameTemplate",
-          "@type": "hydra:IriTemplate",
-          "template": "http://api.example.com/people/{name}",
-          ...
-        }]
-      }
-      -->
-    </pre>
-
-    <p>where</p>
-
-    <ul>
-      <li>resource <i>http://api.example.com/people</i> should have an <i>IriTemplate</i> available
-        as there is a complete definition of the template available at <i>http://api.example.com/doc/</i>.</li>
-      <li>resource <i>http://api.example.com/events</i> should not have an Iri template exposed as there
-        are no additional details available, neither in the initial resources' payload nor in the API documentation.</li>
-    </ul>
 
     <p>IRI expansion should be performed with respect to the specification
       behind the IRI template type (RFC 6570 by default), and the product

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -403,8 +403,8 @@
       it thus makes sense to reduce the response size by leveraging a
       remote context that can easily be cached by a client.</p>
 
-    <p>It is worth to mention that due to fact that hydra is on top of
-      an RDF, which is a graph, it may happen that a related resource
+    <p>It is worth mentioning that due to the fact that Hydra is built on
+      RDF, which is a graph, it may happen that a related resource
       (an object of the relation) may not be fully described in the
       resource's payload. In several circumstances (i.e. payload terms
       defined in <i>API documentation</i> sa described in
@@ -412,23 +412,23 @@
       or <i>IriTemplate</i> expected as a related resource as described in
       <a href="#templated-links">Templated Links</a>) client may
       discover no additional statements describing it. These rules should
-      be considered by the client in those scenarios:
+      be considered by the client in following scenarios:
     </p>
 
     <ul>
       <li>in case of an object expected to be a hypermedia resource does not have all
-        the necessary statements for which it is a subject, client SHOULD look in the
+        the necessary statements for which it is a subject, the client SHOULD look in the
         <i>API documentation</i> for more details</li>
       <li>in case the mentioned object, after consulting an <i>API documentation</i>, still
         does not have all the necessary statements for which it is a subject and both
         mentioned object's Url and Url of the initially obtained resource has the
-        same scheme and authority (by means of [[!RFC3986]] sections 3.1 and 3.2), client
+        same scheme and authority (by means of [[!RFC3986]] sections 3.1 and 3.2), the client
         SHOULD de-reference that Url. If the resource does not have the same scheme and
         authority the client MAY choose to de-reference it (for example if the resource
         originates from another API well-known to the client)</li>
-      <li>in case the mentioned object, still does not have all the necessary
+      <li>in case the mentioned object still does not have all the necessary
         statements for which it is a subject (i.e. de-referencing it failed
-        or statements are missing), client SHOULD either ignore whole
+        or statements are missing), the client SHOULD either ignore the whole
         statement (i.e. for display purposes) or throw an exception (i.e. an
         <i>IriTemplate</i> is about to be resolved and de-referenced)</li>
     </ul>
@@ -480,8 +480,8 @@
     </ul>
 
     <p>Keep in mind that any resource described by any hypermedia control
-      may fail at runtime due to various reasons. Also operation details
-      like <i>returns</i> or <i>possibleStatus</i> may vary at runtime,
+      may fail at runtime due to various reasons. Operation details
+      such as <i>returns</i> or <i>possibleStatus</i> may also vary at runtime,
       which means client SHOULD always verify received payloads at runtime.
       </p>
   </section>
@@ -708,7 +708,7 @@
     <p>These are the simple example scenarios and possible usages are not
       limited to those described above.</p>
 
-    <p>Due to fact an <i>ApiDocumentation</i> as all other resources may fail
+    <p>Due to the fact an <i>ApiDocumentation</i> as all other resources may fail
       at runtime, it is important to take countermeasures.
       A simple strategy to try to recover from such a situation would be to reload
       the <i>ApiDocumentation</i> and redo all pre-computations that were


### PR DESCRIPTION
## Summary
Moved some of the parts of the spec to the first section addressing several issues:

- #21 while the topic was mentioned directly, it was in a place related to API Documentation
- #13 moved rules of external resources handling from IRI Template section to first part of the document
- #61 volatility of the API documentation was mentioned stronger

## More details

While most of the things mentioned in the issues enlisted above were addressed, places where those topics were covered were related to other terms of the vocabulary. I've moved those parts to the paragraph 4.1 Adding Affordances to Representations and reworded them to achieve more generic rules.