### PR TITLE
replaced possibleStatus by statusCode in example

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1267,7 +1267,7 @@
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@type": "****Status****",
-        ****"possibleStatus": 429****,
+        ****"statusCode": 429****,
         "title": "Too Many Requests",
         "description": "A maximum of 500 requests per hour and user is allowed.",
         ...


### PR DESCRIPTION
<!--
  Before proceeding, please read the Pull Request section in CONTRIBUTING.md (linked on the right)
-->

## Summary

Replace property possibleStatus by statusCode in example 27.

<!--
  Short introduction to the proposed changes
-->

## More details

Property `possibleStatus` has range `hydra:Status`. Example shows an integer value. Matching property must be `statusCode`.


