### PR TITLE
Variable representation of individual template mappings

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -554,7 +554,7 @@
       "label": "variable representation",
       "comment": "The representation format to use when expanding the IRI template.",
       "range": "hydra:VariableRepresentation",
-      "domain": ["hydra:IriTemplateMapping", "hydra:IriTemplate"],
+      "domainIncludes": ["hydra:IriTemplateMapping", "hydra:IriTemplate"],
       "isDefinedBy": "http://www.w3.org/ns/hydra/core",
       "vs:term_status": "testing"
     },

--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -554,7 +554,7 @@
       "label": "variable representation",
       "comment": "The representation format to use when expanding the IRI template.",
       "range": "hydra:VariableRepresentation",
-      "domain": "hydra:IriTemplateMapping",
+      "domain": ["hydra:IriTemplateMapping", "hydra:IriTemplate"],
       "isDefinedBy": "http://www.w3.org/ns/hydra/core",
       "vs:term_status": "testing"
     },

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1208,7 +1208,8 @@
       {
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         ****"@type": "IriTemplate"****,
-        ****"template": "http://api.example.com/issues{?q}"****,
+        ****"template": "http://api.example.com/issues{?q,category}"****,
+		****"variableRepresentation": "ExplicitRepresentation"****,
         ****"mapping"****: [
           {
             ****"@type": "IriTemplateMapping"****,
@@ -1216,11 +1217,20 @@
             ****"property": "hydra:freetextQuery"****,
             ****"variableRepresentation": "BasicRepresentation"****,
             ****"required": true****
+          },
+          {
+             ****"@type": "IriTemplateMapping"****,
+             ****"variable": "category"****,
+             ****"property": "schema:category"****
           }
         ]
       }
       -->
     </pre>
+	
+	<p>In this example, the variable <i>category</i> will be serialised using the explicit representation,
+	  derived from the template itself. The variable <i>q</i> on the other hand will override that
+	  to use basic representation.</p>
 
     <p>Similar to how Hydra's <i>Link</i> class allows the definition of
       properties that represent hyperlinks as described in

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1196,7 +1196,7 @@
     <p>The example <i>Description of an IRI Template</i> that was already mentioned
       uses a <i>variableRepresentation</i> on the whole <i>IriTemplate</i>, but
       each mapped variable represented as an <i>IriTemplateMapping</i> can have
-      its own <i>variableRepresentation</i> declaration which MUST override
+      its own <i>variableRepresentation</i> declaration. It MUST override
       the declaration from the <i>IriTemplate</i> level for that very
       <i>IriTemplateMapping</i> as it takes precedence. The example below
       depicts such a situation:
@@ -1209,7 +1209,7 @@
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         ****"@type": "IriTemplate"****,
         ****"template": "http://api.example.com/issues{?q,category}"****,
-		****"variableRepresentation": "ExplicitRepresentation"****,
+        ****"variableRepresentation": "ExplicitRepresentation"****,
         ****"mapping"****: [
           {
             ****"@type": "IriTemplateMapping"****,

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1193,6 +1193,36 @@
       </dl>
     </aside>
 
+    <p>The example <i>Description of an IRI Template</i> that was already mentioned
+      uses a <i>variableRepresentation</i> on the whole <i>IriTemplate</i>, but
+      each mapped variable represented as an <i>IriTemplateMapping</i> can have
+      it's own <i>variableRepresentation</i> declaration which SHOULD override
+      the declaration from the <i>IriTemplate</i> level for that very
+      <i>IriTemplateMapping</i> as it takes precedence. In case no no upper
+      declaration is available, the <i>IriTemplateMapping</i> one SHOULD be in force,
+      as it is shown on the example below.
+    </p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Variable level representation">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        ****"@type": "IriTemplate"****,
+        ****"template": "http://api.example.com/issues{?q}"****,
+        ****"mapping"****: [
+          {
+            ****"@type": "IriTemplateMapping"****,
+            ****"variable": "q"****,
+            ****"property": "hydra:freetextQuery"****,
+            ****"variableRepresentation": "BasicRepresentation"****,
+            ****"required": true****
+          }
+        ]
+      }
+      -->
+    </pre>
+
     <p>Similar to how Hydra's <i>Link</i> class allows the definition of
       properties that represent hyperlinks as described in
       <a class="sectionRef" href="#adding-affordances-to-representations"></a>,

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1196,11 +1196,10 @@
     <p>The example <i>Description of an IRI Template</i> that was already mentioned
       uses a <i>variableRepresentation</i> on the whole <i>IriTemplate</i>, but
       each mapped variable represented as an <i>IriTemplateMapping</i> can have
-      it's own <i>variableRepresentation</i> declaration which SHOULD override
+      its own <i>variableRepresentation</i> declaration which MUST override
       the declaration from the <i>IriTemplate</i> level for that very
-      <i>IriTemplateMapping</i> as it takes precedence. In case no no upper
-      declaration is available, the <i>IriTemplateMapping</i> one SHOULD be in force,
-      as it is shown on the example below.
+      <i>IriTemplateMapping</i> as it takes precedence. The example below
+      depicts such a situation:
     </p>
 
     <pre class="example nohighlight" data-transform="updateExample"


### PR DESCRIPTION
## Summary

Relaxed domain of variableRepresentation to cover both IriTemplate and IriTemplateMapping.

## More details

This pull request addresses issue #244 by relaxing domain of the `variableRepresentation` predicate to `IriTemplate` and `IriTemplateMapping`.