### PR TITLE
Retracting operations

### DIFF
--- a/spec/latest/core/core.jsonld
+++ b/spec/latest/core/core.jsonld
@@ -28,6 +28,7 @@
     "method": "hydra:method",
     "expects": { "@id": "hydra:expects", "@type": "@vocab" },
     "returns": { "@id": "hydra:returns", "@type": "@vocab" },
+    "availability": { "@id": "hydra:availability", "@type": "@vocab" },
     "possibleStatus": { "@id": "hydra:possibleStatus", "@type": "@id" },
     "Status": "hydra:Status",
     "statusCode": "hydra:statusCode",
@@ -164,6 +165,48 @@
       "comment": "A class known to be supported by the Web API",
       "domain": "hydra:ApiDocumentation",
       "range": "rdfs:Class",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:availability",
+      "@type": "rdf:Property",
+      "label": "availability",
+      "comment": "Availability of the operation explicitely stated",
+      "range": "hydra:Availability",
+      "domain": "hydra:Operation",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:Availability",
+      "@type": "hydra:Class",
+      "label": "Availability",
+      "comment": "Availability states when the operation can be invoked.",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:Forbidden",
+      "@type": "hydra:Availability",
+      "label": "Forbidden",
+      "comment": "States an operation previously announced is forbidden in current circumstances.",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:Unauthorized",
+      "@type": "hydra:Availability",
+      "label": "Unauthorized",
+      "comment": "States an operation previously announced should not be invoked as the current user is not authorized to invoke it.",
+      "isDefinedBy": "http://www.w3.org/ns/hydra/core",
+      "vs:term_status": "testing"
+    },
+    {
+      "@id": "hydra:Available",
+      "@type": "hydra:Availability",
+      "label": "Available",
+      "comment": "States an operation is available for invocation. This is a default operation availability.",
       "isDefinedBy": "http://www.w3.org/ns/hydra/core",
       "vs:term_status": "testing"
     },

--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -744,6 +744,83 @@
       without elevating it to the <i>Link</i> SHOULD NOT be implemented as clients
       may not discover such a construct correctly.</p>
 
+    <p>There are rare situations when some supported operations once announced in the
+      API documentation should be retracted, i.e. to reflect current state of the 
+      application or current user capabilities (or lack of them). It is doable
+      with the <i>availability<i> predicate that can be added to the <i>Operation</i>
+      itself. By default all operations are <i>Available</i> without limits and it
+      is up for the server to change that, and for the client to discover any 
+      discrepancies compared against the API documentation in the runtime. Yet
+      server may want to inform the client that at the very moment an operation is either 
+      <i>Forbidden</i> or <i>Unauthorized</i>. The latter MAY be used to notify 
+      client that the user used to invoke the request that provides operation 
+      availability information is currently not authorized for that very operation 
+      to be invoked. The former on the other hand MAY be used to inform that
+      the operation is currently forbidden and client SHOULD NOT invoke it.
+	  Server MAY also provide more custom reasons for which the operation is not
+	  available but it SHOULD provide at least one of the <i>Hydra</i> built in reasons.</p>
+
+    <p>Usage of the <i>availability</i> is restricted only to the <i>Operation</i>s
+      and MUST NOT be used on <i>SupportedOperation</i>s. The <i>availability</i>
+      predicate also MUST take precedence over a supported operation declaration.
+      The operation that comes with <i>availability</i> predicate SHOULD be identified
+      using any of the below enlisted methods:
+      <ul>
+        <li>Iri</li>
+        <li>exact match of a resource described by <i>possibleStatus</i>, <i>method</i>,
+          <i>expects</i>, <i>returns</i> or combination of those.</li>
+      </ul>
+    </p>
+
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Retracting operations - declaration of supported operations">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/doc/#comments",
+        "@type": "Link",
+        "supportedOperation": [
+          {
+            "@type": "Operation",
+            "method": "POST",
+            "expects": "http://api.example.com/doc/#Upload"
+          },
+          {
+            "@type": "Operation",
+            "method": "POST",
+            "expects": "http://api.example.com/doc/#Comment"
+          }
+        ]
+      }
+      -->
+    </pre>
+    <pre class="example nohighlight" data-transform="updateExample"
+         title="Retracting operations - matching">
+      <!--
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "http://api.example.com/doc/",
+        "@type": "Collection",
+        "operation": [
+          {
+            "@type": "Operation",
+            "method": "POST",
+            "expects": "http://api.example.com/doc/#Upload",
+            "availability": "Forbidden"
+          }
+        ]
+      }
+      -->
+    </pre>
+
+    <p>In the example above the operation that expects an uploaded file became
+      <i>Forbidden</i>, while the one expecting a comment remains available as
+      the <i>expects</i> predicate does not match any supported operations.
+      It is still recommended to mark operations being subject for further
+      restrictions with an Iri as from the client perspective this may be
+      easier to implement simple literal Iri comparison rather than to compare
+      graphs of objects.</p>
+
     <p>These are the simple example scenarios and possible usages are not
       limited to those described above.</p>
 


### PR DESCRIPTION
## Summary

This pull-request addresses issue #241.

## More details

I've introduced a `availability` predicate that can mark a specific `Operation` as either `Forbidden` or `Unauthorized`. I didn't want to introduce `NotImplemented` or `ConflictsWithCurrentStateOfResource` suggested in the discussion as I felt these would  conflict with the initial logic of the supported operation (why supporting it if it is not implemented) or it felt irrational (client didn't send a payload yet).

Feel free to deliberate on the approach. It was the simples thing to introduce to keep the vocabulary minimal yet still effective.