### PR TITLE
fix reference from Collection to ApiDocumentation

### DIFF
--- a/spec/latest/core/index.html
+++ b/spec/latest/core/index.html
@@ -1400,7 +1400,7 @@
         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
         "@id": "http://api.example.com/issues",
         "@type": "Collection",
-        ****"api:search": {
+        ****"api:find": {
           "@type": "IriTemplate",
           "template": "/issues?find={name}",
           "mapping": {...}


### PR DESCRIPTION
The change is as followed on Example 28: 

```diff
{
  "@context": "http://www.w3.org/ns/hydra/context.jsonld",
  "@id": "http://api.example.com/api-documentation",
  "@type": "ApiDocumentation",
  "api:find": {
    "supportedOperation": {
      "@type": "SupportedOperation",
      "method": "POST"
    }
  }
}

{
  "@context": "http://www.w3.org/ns/hydra/context.jsonld",
  "@id": "http://api.example.com/issues",
  "@type": "Collection",
-  "api:search": {
+  "api:find": {
    "@type": "IriTemplate",
    "template": "/issues?find={name}",
    "mapping": {...}
  }
}
```

As I don't think it makes sense otherwise.